### PR TITLE
Step9. User-Token 처리 방식 변경 및 logging, error 처리

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/CurrentEntry.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/CurrentEntry.kt
@@ -1,0 +1,8 @@
+package com.yuiyeong.ticketing.application.annotation
+
+/**
+ * Http header 에 User-Token 로 부터 QueueEntry 를 추출함을 나타내는 annotation
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentEntry

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/RequiresUserToken.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/RequiresUserToken.kt
@@ -1,0 +1,12 @@
+package com.yuiyeong.ticketing.application.annotation
+
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+
+/**
+ * Http header 에 User-Token 이 필수임을 나타내는 annotation
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RequiresUserToken(
+    val allowedStatus: Array<QueueEntryStatus> = [QueueEntryStatus.PROCESSING],
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/scheduler/OccupationScheduler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/scheduler/OccupationScheduler.kt
@@ -1,21 +1,19 @@
 package com.yuiyeong.ticketing.application.scheduler
 
-import com.yuiyeong.ticketing.application.usecase.reservation.ExpireOccupationUseCase
+import com.yuiyeong.ticketing.application.usecase.reservation.ExpireOccupationsUseCase
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class OccupationScheduler {
-    @Autowired
-    private lateinit var expireOccupationUseCase: ExpireOccupationUseCase
-
-    @Scheduled(fixedRate = 60000) // 1분마다 실행
+class OccupationScheduler(
+    private val expireOccupationsUseCase: ExpireOccupationsUseCase,
+) {
+    @Scheduled(fixedRateString = "#{@schedulerProperties.occupationFixedRate}")
     fun expireOverdueOccupations() {
         try {
-            // token 만료
-            val expiredOccupations = expireOccupationUseCase.execute()
+            // 점유 만료
+            val expiredOccupations = expireOccupationsUseCase.execute()
             logger.info("Expired ${expiredOccupations.size} occupations.")
         } catch (e: Exception) {
             logger.error("Error from expireOverdueOccupations: ${e.message}", e)

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/scheduler/QueueScheduler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/scheduler/QueueScheduler.kt
@@ -3,19 +3,15 @@ package com.yuiyeong.ticketing.application.scheduler
 import com.yuiyeong.ticketing.application.usecase.queue.ActivateWaitingEntriesUseCase
 import com.yuiyeong.ticketing.application.usecase.queue.ExpireWaitingEntryUseCase
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class QueueScheduler {
-    @Autowired
-    private lateinit var activateWaitingEntriesUseCase: ActivateWaitingEntriesUseCase
-
-    @Autowired
-    private lateinit var expireWaitingEntryUseCase: ExpireWaitingEntryUseCase
-
-    @Scheduled(fixedRate = 5000) // 5초 뒤부터, 5초 마다 실행
+class QueueScheduler(
+    private val activateWaitingEntriesUseCase: ActivateWaitingEntriesUseCase,
+    private val expireWaitingEntryUseCase: ExpireWaitingEntryUseCase,
+) {
+    @Scheduled(fixedRateString = "#{@schedulerProperties.queueFixedRate}")
     fun processQueue() {
         try {
             // token 만료

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/service/TicketingExceptionService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/service/TicketingExceptionService.kt
@@ -1,74 +1,33 @@
 package com.yuiyeong.ticketing.application.service
 
+import com.yuiyeong.ticketing.application.dto.ErrorStatusCode
 import com.yuiyeong.ticketing.application.dto.TicketingError
-import com.yuiyeong.ticketing.domain.exception.ConcertEventNotFoundException
-import com.yuiyeong.ticketing.domain.exception.ConcertNotFoundException
-import com.yuiyeong.ticketing.domain.exception.InsufficientBalanceException
-import com.yuiyeong.ticketing.domain.exception.InvalidAmountException
-import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
-import com.yuiyeong.ticketing.domain.exception.OccupationAlreadyExpiredException
-import com.yuiyeong.ticketing.domain.exception.SeatNotFoundException
-import com.yuiyeong.ticketing.domain.exception.SeatUnavailableException
-import com.yuiyeong.ticketing.domain.exception.TokenNotFoundException
-import com.yuiyeong.ticketing.domain.exception.TokenNotProcessableException
-import com.yuiyeong.ticketing.domain.exception.WalletNotFoundException
+import com.yuiyeong.ticketing.domain.exception.BadRequestException
+import com.yuiyeong.ticketing.domain.exception.ErrorCode
+import com.yuiyeong.ticketing.domain.exception.NotFoundException
 import org.springframework.stereotype.Service
 
 @Service
 class TicketingExceptionService {
-    fun handleException(ex: Exception): TicketingError =
-        when (ex) {
-            is InvalidTokenException ->
-                TicketingError(TicketingErrorCode.INVALID_TOKEN, ex.notNullMessage)
-
-            is TokenNotProcessableException ->
-                TicketingError(TicketingErrorCode.INVALID_TOKEN_STATUS, ex.notNullMessage)
-
-            is InvalidAmountException ->
-                TicketingError(TicketingErrorCode.INVALID_AMOUNT, ex.notNullMessage)
-
-            is SeatUnavailableException ->
-                TicketingError(TicketingErrorCode.INVALID_SEAT_STATUS, ex.notNullMessage)
-
-            is InsufficientBalanceException ->
-                TicketingError(TicketingErrorCode.INSUFFICIENT_BALANCE, ex.notNullMessage)
-
-            is OccupationAlreadyExpiredException ->
-                TicketingError(TicketingErrorCode.OCCUPATION_EXPIRED, ex.notNullMessage)
-
-            is TokenNotFoundException ->
-                TicketingError(TicketingErrorCode.NOT_FOUND_IN_QUEUE, ex.notNullMessage)
-
-            is ConcertNotFoundException ->
-                TicketingError(TicketingErrorCode.NOT_FOUND_CONCERT, ex.notNullMessage)
-
-            is ConcertEventNotFoundException ->
-                TicketingError(TicketingErrorCode.NOT_FOUND_CONCERT_EVENT, ex.notNullMessage)
-
-            is SeatNotFoundException ->
-                TicketingError(TicketingErrorCode.NOT_FOUND_SEAT, ex.notNullMessage)
-
-            is WalletNotFoundException ->
-                TicketingError(TicketingErrorCode.NOT_FOUND_WALLET, ex.notNullMessage)
-
-            else -> TicketingError(TicketingErrorCode.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.")
+    fun handleException(e: Exception): TicketingError =
+        when (e) {
+            is BadRequestException ->
+                TicketingError(
+                    ErrorStatusCode.BAD_REQUEST,
+                    e.errorCode.name.lowercase(),
+                    e.errorCode.message,
+                )
+            is NotFoundException ->
+                TicketingError(
+                    ErrorStatusCode.NOT_FOUND,
+                    e.errorCode.name.lowercase(),
+                    e.errorCode.message,
+                )
+            else ->
+                TicketingError(
+                    ErrorStatusCode.INTERNAL_ERROR,
+                    ErrorCode.INTERNAL_SERVER_ERROR.name.lowercase(),
+                    ErrorCode.INTERNAL_SERVER_ERROR.message,
+                )
         }
-}
-
-enum class TicketingErrorCode {
-    INVALID_TOKEN,
-    INVALID_TOKEN_STATUS,
-    INVALID_SEAT_STATUS,
-    INSUFFICIENT_BALANCE,
-    OCCUPATION_EXPIRED,
-    INVALID_AMOUNT,
-    NOT_FOUND_IN_QUEUE,
-    NOT_FOUND_CONCERT,
-    NOT_FOUND_CONCERT_EVENT,
-    NOT_FOUND_SEAT,
-    NOT_FOUND_WALLET,
-    INTERNAL_SERVER_ERROR,
-    ;
-
-    override fun toString(): String = name.lowercase()
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/common/ZonedDateTimeExtension.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/common/ZonedDateTimeExtension.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.common
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+val ZonedDateTime.asUtc: ZonedDateTime
+    get() = withZoneSameLocal(ZoneOffset.UTC)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/FilterConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/FilterConfig.kt
@@ -1,0 +1,22 @@
+package com.yuiyeong.ticketing.config
+
+import com.yuiyeong.ticketing.presentation.filter.TicketingLoggingFilter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FilterConfig(
+    private val loggingProperties: LoggingProperties,
+) {
+    @Bean
+    @ConditionalOnBean(TicketingLoggingFilter::class)
+    fun loggingFilter(ticketingLoggingFilter: TicketingLoggingFilter): FilterRegistrationBean<TicketingLoggingFilter> {
+        val registrationBean = FilterRegistrationBean<TicketingLoggingFilter>()
+        registrationBean.filter = ticketingLoggingFilter
+        registrationBean.addUrlPatterns("/*")
+        registrationBean.order = 1
+        return registrationBean
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/LoggingProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/LoggingProperties.kt
@@ -1,0 +1,12 @@
+package com.yuiyeong.ticketing.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "logging.request-response")
+class LoggingProperties {
+    var enabled: Boolean = false
+    var previewLength: Int = 200
+    var maxContentLength: Int = 524288 // 500 KB
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/SchedulerProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/SchedulerProperties.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "config.scheduler")
+class SchedulerProperties {
+    var queueFixedRate: Long = 60000 // 1분
+    var occupationFixedRate: Long = 60000 // 1분
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
@@ -1,0 +1,23 @@
+package com.yuiyeong.ticketing.config
+
+import com.yuiyeong.ticketing.application.usecase.token.ValidateTokenUseCase
+import com.yuiyeong.ticketing.presentation.interceptor.UserTokenInterceptor
+import com.yuiyeong.ticketing.presentation.resolver.EntryArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val validateTokenUseCase: ValidateTokenUseCase,
+    private val entryArgumentResolver: EntryArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(UserTokenInterceptor(validateTokenUseCase))
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(entryArgumentResolver)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/exception/ErrorCode.kt
@@ -1,0 +1,29 @@
+package com.yuiyeong.ticketing.domain.exception
+
+enum class ErrorCode(
+    val message: String,
+) {
+    INTERNAL_SERVER_ERROR("예기치 못한 에러가 발생했습니다."),
+    INVALID_TOKEN("유효하지 않은 token 입니다."),
+    TOKEN_NOT_PROCESSABLE("이 token 은 작업할 수 없는 상태압니다."),
+    TOKEN_NOT_FOUND("해당 토큰으로 대기 중인 정보를 찾을 수 없습니다."),
+    CONCERT_NOT_FOUND("요청한 콘서트를 찾을 수 없습니다."),
+    CONCERT_EVENT_NOT_FOUND("요청한 콘서트 이벤트를 찾을 수 없습니다."),
+    SEAT_NOT_FOUND("요청한 좌석을 찾을 수 없습니다."),
+    WALLET_NOT_FOUND("요청한 사용자의 잔액을 찾을 수 없습니다."),
+    SEAT_UNAVAILABLE("다른 사용자가 선택한 좌석이거나 이미 예약된 좌석입니다."),
+    SEAT_ALREADY_UNAVAILABLE("이미 사용불가한 좌석입니다."),
+    INVALID_AMOUNT("유효하지 않은 충전 금액입니다."),
+    INSUFFICIENT_BALANCE("잔액이 부족합니다."),
+    OCCUPATION_NOT_FOUND("선택한 좌석을 찾을 수 없습니다."),
+    OCCUPATION_ALREADY_EXPIRED("좌석 선택이 만료되었습니다."),
+    OCCUPATION_ALREADY_RELEASED("이미 예약된 좌석입니다."),
+    RESERVATION_NOT_FOUND("요청한 예약을 찾을 수 없습니다."),
+    RESERVATION_NOT_OPENED("예약 기간이 아닙니다."),
+    RESERVATION_ALREADY_CONFIRMED("이미 예약이 완료되었습니다."),
+    QUEUE_ENTRY_ALREADY_PROCESSING("이미 작업 중인 상태입니다."),
+    QUEUE_ENTRY_ALREADY_EXITED("이미 대기열에서 나간 상태입니다."),
+    QUEUE_ENTRY_ALREADY_EXPIRED("이미 만료된 token 입니다."),
+    QUEUE_ENTRY_OVERDUE("만료 시간이 지난 token 입니다."),
+    TRANSACTION_NOT_FOUND("요청한 트랜잭션을 찾을 수 없습니다."),
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/exception/TicketingException.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/exception/TicketingException.kt
@@ -1,54 +1,57 @@
 package com.yuiyeong.ticketing.domain.exception
 
 sealed class TicketingException(
-    message: String,
-) : RuntimeException(message) {
-    val notNullMessage: String
-        get() = message!!
-}
+    val errorCode: ErrorCode,
+) : RuntimeException()
 
-class InvalidTokenException : TicketingException("유효하지 않은 token 입니다.")
+sealed class BadRequestException(
+    errorCode: ErrorCode,
+) : TicketingException(errorCode)
 
-class TokenNotProcessableException : TicketingException("이 token 은 작업할 수 없는 상태압니다.")
+sealed class NotFoundException(
+    errorCode: ErrorCode,
+) : TicketingException(errorCode)
 
-class TokenNotFoundException : TicketingException("해당 토큰으로 대기 중인 정보를 찾을 수 없습니다.")
+class InvalidTokenException : BadRequestException(ErrorCode.INVALID_TOKEN)
 
-class ConcertNotFoundException : TicketingException("요청한 콘서트를 찾을 수 없습니다.")
+class TokenNotProcessableException : BadRequestException(ErrorCode.TOKEN_NOT_PROCESSABLE)
 
-class ConcertEventNotFoundException : TicketingException("요청한 콘서트 이벤트를 찾을 수 없습니다.")
+class TokenNotFoundException : NotFoundException(ErrorCode.TOKEN_NOT_FOUND)
 
-class SeatNotFoundException : TicketingException("요청한 좌석을 찾을 수 없습니다.")
+class ConcertNotFoundException : NotFoundException(ErrorCode.CONCERT_NOT_FOUND)
 
-class WalletNotFoundException : TicketingException("요청한 사용자의 잔액을 찾을 수 없습니다.")
+class ConcertEventNotFoundException : NotFoundException(ErrorCode.CONCERT_EVENT_NOT_FOUND)
 
-class SeatUnavailableException : TicketingException("다른 사용자가 선택한 좌석이거나 이미 예약된 좌석입니다.")
+class SeatNotFoundException : NotFoundException(ErrorCode.SEAT_NOT_FOUND)
 
-class SeatAlreadyUnavailableException : TicketingException("이미 사용불가한 좌석입니다.")
+class WalletNotFoundException : NotFoundException(ErrorCode.WALLET_NOT_FOUND)
 
-class InvalidAmountException : TicketingException("유효하지 않은 충전 금액입니다.")
+class SeatUnavailableException : BadRequestException(ErrorCode.SEAT_UNAVAILABLE)
 
-class InsufficientBalanceException : TicketingException("잔액이 부족합니다.")
+class SeatAlreadyUnavailableException : BadRequestException(ErrorCode.SEAT_ALREADY_UNAVAILABLE)
 
-class OccupationNotFoundException : TicketingException("선택한 좌석을 찾을 수 없습니다.")
+class InvalidAmountException : BadRequestException(ErrorCode.INVALID_AMOUNT)
 
-class OccupationAlreadyExpiredException : TicketingException("좌석 선택이 만료되었습니다.")
+class InsufficientBalanceException : BadRequestException(ErrorCode.INSUFFICIENT_BALANCE)
 
-class OccupationAlreadyReleaseException : TicketingException("이미 예약된 좌석입니다.")
+class OccupationNotFoundException : NotFoundException(ErrorCode.OCCUPATION_NOT_FOUND)
 
-class ReservationNotFoundException : TicketingException("요청한 예약을 찾을 수 없습니다.")
+class OccupationAlreadyExpiredException : BadRequestException(ErrorCode.OCCUPATION_ALREADY_EXPIRED)
 
-class ReservationNotOpenedException : TicketingException("예약 기간이 아닙니다.")
+class OccupationAlreadyReleaseException : BadRequestException(ErrorCode.OCCUPATION_ALREADY_RELEASED)
 
-class ReservationAlreadyConfirmedException : TicketingException("이미 예약이 완료되었습니다.")
+class ReservationNotFoundException : NotFoundException(ErrorCode.RESERVATION_NOT_FOUND)
 
-class ReservationAlreadyCanceledException : TicketingException("이미 취소된 예약입니다.")
+class ReservationNotOpenedException : BadRequestException(ErrorCode.RESERVATION_NOT_OPENED)
 
-class QueueEntryAlreadyProcessingException : TicketingException("이미 작업 중인 상태입니다.")
+class ReservationAlreadyConfirmedException : BadRequestException(ErrorCode.RESERVATION_ALREADY_CONFIRMED)
 
-class QueueEntryAlreadyExitedException : TicketingException("이미 대기열에서 나간 상태입니다.")
+class QueueEntryAlreadyProcessingException : BadRequestException(ErrorCode.QUEUE_ENTRY_ALREADY_PROCESSING)
 
-class QueueEntryAlreadyExpiredException : TicketingException("이미 만료된 token 입니다.")
+class QueueEntryAlreadyExitedException : BadRequestException(ErrorCode.QUEUE_ENTRY_ALREADY_EXITED)
 
-class QueueEntryOverdueException : TicketingException("만료 시간이 지난 token 입니다.")
+class QueueEntryAlreadyExpiredException : BadRequestException(ErrorCode.QUEUE_ENTRY_ALREADY_EXPIRED)
 
-class TransactionNotFoundException : TicketingException("요청한 트랜잭션을 찾을 수 없습니다.")
+class QueueEntryOverdueException : BadRequestException(ErrorCode.QUEUE_ENTRY_OVERDUE)
+
+class TransactionNotFoundException : NotFoundException(ErrorCode.TRANSACTION_NOT_FOUND)

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/security/JwtTokenService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/security/JwtTokenService.kt
@@ -1,0 +1,60 @@
+package com.yuiyeong.ticketing.infrastructure.security
+
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import com.yuiyeong.ticketing.domain.repository.QueueEntryRepository
+import com.yuiyeong.ticketing.domain.service.TokenService
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.ZonedDateTime
+import java.util.Date
+import java.util.UUID
+import javax.crypto.SecretKey
+
+@Component
+class JwtTokenService(
+    @Value("\${jwt.secret}")
+    private val jwtSecret: String,
+    private val queueEntryRepository: QueueEntryRepository,
+) : TokenService {
+    private val signingKey: SecretKey by lazy {
+        Keys.hmacShaKeyFor(jwtSecret.toByteArray())
+    }
+
+    override fun generateToken(
+        userId: Long,
+        issuedAt: ZonedDateTime,
+        expiresAt: ZonedDateTime,
+    ): String =
+        Jwts
+            .builder()
+            .subject(userId.toString())
+            .issuedAt(Date.from(issuedAt.toInstant()))
+            .expiration(Date.from(expiresAt.toInstant()))
+            .id(UUID.randomUUID().toString())
+            .signWith(signingKey, Jwts.SIG.HS256)
+            .compact()
+
+    override fun validateToken(token: String): QueueEntry {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+        } catch (e: JwtException) {
+            logger.info("Error occurs when validateToken($token);${e.javaClass.name} | ${e.message}")
+            throw InvalidTokenException()
+        }
+
+        return queueEntryRepository.findOneByToken(token) ?: throw InvalidTokenException()
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(JwtTokenService::class.java)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertController.kt
@@ -1,5 +1,6 @@
 package com.yuiyeong.ticketing.presentation.controller
 
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
 import com.yuiyeong.ticketing.application.usecase.concert.GetAvailableConcertEventsUseCase
 import com.yuiyeong.ticketing.config.swagger.annotation.api.AvailableConcertEventsApiDoc
 import com.yuiyeong.ticketing.presentation.dto.ConcertEventResponseDto
@@ -7,7 +8,6 @@ import com.yuiyeong.ticketing.presentation.dto.response.TicketingListResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,15 +18,12 @@ class ConcertController(
     private val getAvailableConcertEventsUseCase: GetAvailableConcertEventsUseCase,
 ) {
     @GetMapping("{concertId}/available-events")
+    @RequiresUserToken
     @AvailableConcertEventsApiDoc
     fun getAvailableEvents(
-        @RequestHeader(name = "User-Token", required = false) userToken: String?,
         @PathVariable("concertId") concertId: Long,
     ): TicketingListResponse<ConcertEventResponseDto> {
-        val list =
-            getAvailableConcertEventsUseCase
-                .execute(userToken, concertId)
-                .map { ConcertEventResponseDto.from(it) }
+        val list = getAvailableConcertEventsUseCase.execute(concertId).map { ConcertEventResponseDto.from(it) }
         return TicketingListResponse(list)
     }
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/QueueController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/QueueController.kt
@@ -1,5 +1,7 @@
 package com.yuiyeong.ticketing.presentation.controller
 
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
 import com.yuiyeong.ticketing.application.dto.QueueEntryResult
 import com.yuiyeong.ticketing.application.usecase.queue.EnterQueueUseCase
 import com.yuiyeong.ticketing.config.swagger.annotation.api.QueueStatusApiDoc
@@ -13,7 +15,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -33,9 +34,17 @@ class QueueController(
     }
 
     @GetMapping("status")
+    @RequiresUserToken(
+        allowedStatus = [
+            QueueEntryStatus.WAITING,
+            QueueEntryStatus.PROCESSING,
+            QueueEntryStatus.EXITED,
+            QueueEntryStatus.EXPIRED,
+        ],
+    )
     @QueueStatusApiDoc
     fun getStatus(
-        @RequestHeader(name = "User-Token", required = false) userToken: String?,
+        @CurrentEntry entry: QueueEntryResult,
     ): TicketingResponse<QueuePositionResponseDto> {
         val data = QueuePositionResponseDto.from(entry)
         return TicketingResponse(data)

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/filter/TicketingLoggingFilter.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/filter/TicketingLoggingFilter.kt
@@ -1,0 +1,121 @@
+package com.yuiyeong.ticketing.presentation.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yuiyeong.ticketing.config.LoggingProperties
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.util.Locale
+
+@Component
+@ConditionalOnProperty(name = ["logging.request-response.enabled"], havingValue = "true")
+class TicketingLoggingFilter(
+    private val loggingProperties: LoggingProperties,
+) : OncePerRequestFilter() {
+    private val filterLogger = LoggerFactory.getLogger(TicketingLoggingFilter::class.java)
+    private val objectMapper = ObjectMapper()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestWrapper = ContentCachingRequestWrapper(request)
+        val responseWrapper = ContentCachingResponseWrapper(response)
+
+        val startTime = System.currentTimeMillis()
+
+        // request 처리
+        filterChain.doFilter(requestWrapper, responseWrapper)
+
+        // 로깅
+        logRequestResponse(requestWrapper, responseWrapper, System.currentTimeMillis() - startTime)
+
+        // response 전달
+        responseWrapper.copyBodyToResponse()
+    }
+
+    private fun logRequestResponse(
+        request: ContentCachingRequestWrapper,
+        response: ContentCachingResponseWrapper,
+        elapsedTime: Long,
+    ) {
+        val method = request.method
+        val uri = request.requestURI
+        val queryString = request.queryString?.let { "?$it" } ?: ""
+        val status = response.status
+
+        val requestBody = getRequestBody(request)
+        val responseBody = getResponseBody(response)
+
+        filterLogger.info("($elapsedTime ms) $method $uri$queryString | $status | $requestBody | $responseBody")
+    }
+
+    private fun getRequestBody(request: ContentCachingRequestWrapper): String {
+        val contentLength = request.contentLength
+        return when {
+            contentLength <= 0 -> "Empty body"
+            contentLength > loggingProperties.maxContentLength ->
+                "Too Large Body($contentLength bytes), summary: ${
+                    getBodySummary(
+                        request.contentAsByteArray,
+                        request.contentType,
+                    )
+                }"
+            else -> getCompactBody(request.contentAsByteArray)
+        }
+    }
+
+    private fun getResponseBody(response: ContentCachingResponseWrapper): String {
+        val contentLength = response.contentSize
+        return when {
+            contentLength <= 0 -> "Empty body"
+            contentLength > loggingProperties.maxContentLength ->
+                "Too Large Body($contentLength bytes), summary: ${
+                    getBodySummary(
+                        response.contentAsByteArray,
+                        response.contentType,
+                    )
+                }"
+            else -> getCompactBody(response.contentAsByteArray)
+        }
+    }
+
+    private fun getBodySummary(
+        content: ByteArray,
+        contentType: String?,
+    ): String {
+        val info = mutableListOf<String>()
+        info.add("Size: ${content.size} bytes")
+        info.add("Type: $contentType")
+        info.add("Preview: ${String(content.take(loggingProperties.previewLength).toByteArray())}...")
+        return info.joinToString(" | ")
+    }
+
+    private fun getCompactBody(content: ByteArray): String {
+        if (content.isEmpty()) return "-"
+
+        return try {
+            val bodyMap = objectMapper.readValue(content, Map::class.java)
+            val compactMap =
+                bodyMap.mapValues { (key, value) ->
+                    when {
+                        // 민감 정보 마스킹
+                        key.toString().lowercase(Locale.getDefault()).contains("token") -> "********"
+                        value is String && value.length > 100 -> "${value.substring(0, 97)}..."
+                        else -> value
+                    }
+                }
+            objectMapper.writeValueAsString(compactMap)
+        } catch (e: Exception) {
+            // JSON 파싱에 실패한 경우, 문자열의 일부만 반환
+            String(content).let { if (it.length > 100) "${it.substring(0, 97)}..." else it }
+        }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/interceptor/UserTokenInterceptor.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/interceptor/UserTokenInterceptor.kt
@@ -1,0 +1,42 @@
+package com.yuiyeong.ticketing.presentation.interceptor
+
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.usecase.token.ValidateTokenUseCase
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.domain.exception.TokenNotProcessableException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class UserTokenInterceptor(
+    private val validateTokenUseCase: ValidateTokenUseCase,
+) : HandlerInterceptor {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        if (handler is HandlerMethod) {
+            val requiresUserToken = handler.getMethodAnnotation(RequiresUserToken::class.java) ?: return true
+
+            val token = request.getHeader(HEADER_USER_TOKEN) ?: throw InvalidTokenException()
+            val entryResult = validateTokenUseCase.execute(token)
+
+            return if (requiresUserToken.allowedStatus.isEmpty() || entryResult.status in requiresUserToken.allowedStatus) {
+                request.setAttribute(ATTR_QUEUE_ENTRY, entryResult)
+                true
+            } else {
+                throw TokenNotProcessableException()
+            }
+        }
+        return true
+    }
+
+    companion object {
+        const val ATTR_QUEUE_ENTRY = "queue_entry"
+        private const val HEADER_USER_TOKEN = "User-Token"
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/resolver/EntryArgumentResolver.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/resolver/EntryArgumentResolver.kt
@@ -1,0 +1,30 @@
+package com.yuiyeong.ticketing.presentation.resolver
+
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.presentation.interceptor.UserTokenInterceptor
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class EntryArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(CurrentEntry::class.java) && parameter.parameterType == QueueEntryResult::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Any {
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java)
+        return request?.getAttribute(UserTokenInterceptor.ATTR_QUEUE_ENTRY) as? QueueEntryResult
+            ?: throw InvalidTokenException()
+    }
+}


### PR DESCRIPTION
## UserTokenInterceptor

- 코드 보기 좋은 PR: #22 
- @RequiresUserToken 가 있을 때만 request 에 대해서 검증을 하도록했습니다.
- Header 에 있는 User-Token 에 대해서 유효성 검사를 합니다.
- 유효한 QueueEntory 의 status 가 허용된 status 에 포함되는지검사합니다.
- 마지막으로 attribute 에 유효한 QueueEntry 를 넣어줍니다.

## EntryArgumentResolver

- 코드 보기 좋은 PR: #22 
- @CurrentEntry 가 붙은 parameter 가 QueueEntry 면, request 의 Attribute 에서 추출하여 반환합니다.

## Logging
- 코드 보기 좋은 PR: #24 
### TicketingLoggingFilter 

- `logging.request-response.enabled` 이 true 일 때만, Component 로 만들어지도록 했습니다.
- 너무 큰 내용에 대해서는 메시지를 따로 만들어 로깅할 수 있도록 했습니다.

### FilterConfig

- TicketingLoggingFilter 를 Bean 으로 등록합니다.
- TicketingLoggingFilter 의 조건에 따라 Bean 으로 등록하도록 했습니다.

### LoggingProperties

- logging 관련 설정값을 이 class 로 주입받아 사용할 수 있도록 했습니다.

## Error 처리
- domain.exception.TicketingException 으로 커스텀 exception 을 만들었습니다.
- BadRequestException 과 NotFoundException 로 status 를 표현했습니다.
- domain.exception.ErrorCode 를 사용하여 Error 을 관리할 수 있도록 수정하였습니다.

# ReviewPoint
### UserTokenInterceptor
- 유효성 검사는 UseCase 를 이용해서 하고 있는데, status 에 대한 처리는 interceptor 안에서 하고 있는데 이부분 확인부탁드립니다.
- 유효성을 검사한 후 token 으로 부터 QueueEntry 를 DB 에서 가져오고 있습니다. 이게 성능상에 문제가 될 수 있는지 확인 부탁드립니다.