### PR TITLE
Step10. Infrastucture 계층 구현

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/TicketingApplication.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/TicketingApplication.kt
@@ -2,10 +2,12 @@ package com.yuiyeong.ticketing
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.TimeZone
 
 @EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 class TicketingApplication
 

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/BaseEntity.kt
@@ -1,0 +1,31 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.common.asUtc
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.ZonedDateTime
+
+@MappedSuperclass
+@EntityListeners(value = [AuditingEntityListener::class])
+abstract class BaseEntity(
+    @Column(nullable = false, updatable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now().asUtc,
+    @Column(nullable = false)
+    var updatedAt: ZonedDateTime = ZonedDateTime.now().asUtc,
+) {
+    @PrePersist
+    fun prePersist() {
+        val now = ZonedDateTime.now().asUtc
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun preUpdate() {
+        updatedAt = ZonedDateTime.now().asUtc
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ConcertEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ConcertEntity.kt
@@ -1,0 +1,37 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Concert
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "concert")
+class ConcertEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val title: String,
+    val singer: String,
+    val description: String,
+) : BaseEntity() {
+    fun toConcert(): Concert =
+        Concert(
+            id = id,
+            title = title,
+            singer = singer,
+            description = description,
+        )
+
+    companion object {
+        fun from(concert: Concert): ConcertEntity =
+            ConcertEntity(
+                id = concert.id,
+                title = concert.title,
+                singer = concert.singer,
+                description = concert.description,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ConcertEventEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ConcertEventEntity.kt
@@ -1,0 +1,59 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.ConcertEvent
+import com.yuiyeong.ticketing.domain.vo.DateTimeRange
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "concert_event")
+class ConcertEventEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val concert: ConcertEntity,
+    val venue: String,
+    val reservationStartAt: ZonedDateTime,
+    val reservationEndAt: ZonedDateTime,
+    val startAt: ZonedDateTime,
+    val duration: Long,
+    val maxSeatCount: Int,
+    val availableSeatCount: Int,
+) : BaseEntity() {
+    fun toConcertEvent(): ConcertEvent =
+        ConcertEvent(
+            id = id,
+            concert = concert.toConcert(),
+            venue = venue,
+            reservationPeriod = DateTimeRange(reservationStartAt, reservationEndAt),
+            performanceSchedule = DateTimeRange(startAt, startAt.plusMinutes(duration)),
+            maxSeatCount = maxSeatCount,
+            availableSeatCount = availableSeatCount,
+        )
+
+    companion object {
+        fun from(concertEvent: ConcertEvent): ConcertEventEntity =
+            ConcertEventEntity(
+                id = concertEvent.id,
+                concert = ConcertEntity.from(concertEvent.concert),
+                venue = concertEvent.venue,
+                reservationStartAt = concertEvent.reservationPeriod.start,
+                reservationEndAt = concertEvent.reservationPeriod.end,
+                startAt = concertEvent.performanceSchedule.start,
+                duration = concertEvent.performanceSchedule.getDurationAsMin(),
+                maxSeatCount = concertEvent.maxSeatCount,
+                availableSeatCount = concertEvent.availableSeatCount,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/OccupationEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/OccupationEntity.kt
@@ -1,0 +1,75 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Occupation
+import com.yuiyeong.ticketing.domain.model.OccupationStatus
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "occupation")
+class OccupationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val concertEventId: Long,
+    val status: OccupationEntityStatus,
+    val expiresAt: ZonedDateTime,
+    val expiredAt: ZonedDateTime?,
+    @OneToMany(mappedBy = "occupation", cascade = [CascadeType.ALL])
+    val seatAllocations: List<SeatAllocationEntity> = listOf(),
+) : BaseEntity() {
+    fun toOccupation(): Occupation =
+        Occupation(
+            id = id,
+            userId = userId,
+            concertEventId = concertEventId,
+            allocations = seatAllocations.map { it.toSeatAllocation() },
+            status = status.toOccupationStatus(),
+            createdAt = createdAt,
+            expiresAt = expiresAt,
+            expiredAt = expiredAt,
+        )
+
+    companion object {
+        fun from(occupation: Occupation): OccupationEntity =
+            OccupationEntity(
+                id = occupation.id,
+                userId = occupation.userId,
+                concertEventId = occupation.concertEventId,
+                status = OccupationEntityStatus.from(occupation.status),
+                expiresAt = occupation.expiresAt,
+                expiredAt = occupation.expiredAt,
+                seatAllocations = occupation.allocations.map { SeatAllocationEntity.from(it) },
+            )
+    }
+}
+
+enum class OccupationEntityStatus {
+    ACTIVE,
+    RELEASED,
+    EXPIRED,
+    ;
+
+    fun toOccupationStatus(): OccupationStatus =
+        when (this) {
+            ACTIVE -> OccupationStatus.ACTIVE
+            RELEASED -> OccupationStatus.RELEASED
+            EXPIRED -> OccupationStatus.EXPIRED
+        }
+
+    companion object {
+        fun from(occupationStatus: OccupationStatus): OccupationEntityStatus =
+            when (occupationStatus) {
+                OccupationStatus.ACTIVE -> ACTIVE
+                OccupationStatus.RELEASED -> RELEASED
+                OccupationStatus.EXPIRED -> EXPIRED
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/PaymentEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/PaymentEntity.kt
@@ -1,0 +1,94 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Payment
+import com.yuiyeong.ticketing.domain.model.PaymentMethod
+import com.yuiyeong.ticketing.domain.model.PaymentStatus
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "payment")
+class PaymentEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val transactionId: Long?,
+    val reservationId: Long,
+    val amount: BigDecimal,
+    val paymentMethod: PaymentEntityMethod,
+    val status: PaymentEntityStatus,
+    val failureReason: String?,
+) : BaseEntity() {
+    fun toPayment(): Payment =
+        Payment(
+            id = id,
+            userId = userId,
+            transactionId = transactionId,
+            reservationId = reservationId,
+            amount = amount,
+            status = status.toPaymentStatus(),
+            paymentMethod = paymentMethod.toPaymentMethod(),
+            failureReason = failureReason,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun from(payment: Payment): PaymentEntity =
+            PaymentEntity(
+                id = payment.id,
+                userId = payment.userId,
+                transactionId = payment.transactionId,
+                reservationId = payment.reservationId,
+                amount = payment.amount,
+                paymentMethod = PaymentEntityMethod.from(payment.paymentMethod),
+                status = PaymentEntityStatus.from(payment.status),
+                failureReason = payment.failureReason,
+            )
+    }
+}
+
+enum class PaymentEntityStatus {
+    PENDING,
+    SUCCESS,
+    FAILED,
+    ;
+
+    fun toPaymentStatus(): PaymentStatus =
+        when (this) {
+            PENDING -> PaymentStatus.PENDING
+            SUCCESS -> PaymentStatus.COMPLETED
+            FAILED -> PaymentStatus.FAILED
+        }
+
+    companion object {
+        fun from(paymentStatus: PaymentStatus): PaymentEntityStatus =
+            when (paymentStatus) {
+                PaymentStatus.PENDING -> PENDING
+                PaymentStatus.COMPLETED -> SUCCESS
+                PaymentStatus.FAILED -> FAILED
+            }
+    }
+}
+
+enum class PaymentEntityMethod {
+    WALLET,
+    ;
+
+    fun toPaymentMethod(): PaymentMethod =
+        when (this) {
+            WALLET -> PaymentMethod.WALLET
+        }
+
+    companion object {
+        fun from(paymentMethod: PaymentMethod): PaymentEntityMethod =
+            when (paymentMethod) {
+                PaymentMethod.WALLET -> WALLET
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/QueueEntryEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/QueueEntryEntity.kt
@@ -1,0 +1,81 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "user_queue")
+class QueueEntryEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val token: String,
+    val queuePosition: Long,
+    val status: QueueEntryEntityStatus,
+    val expiresAt: ZonedDateTime,
+    val processedAt: ZonedDateTime?,
+    val exitedAt: ZonedDateTime?,
+    val expiredAt: ZonedDateTime?,
+) : BaseEntity() {
+    fun toQueueEntry(): QueueEntry =
+        QueueEntry(
+            id = id,
+            userId = userId,
+            token = token,
+            position = queuePosition,
+            status = status.toQueueEntryStatus(),
+            enteredAt = createdAt,
+            expiresAt = expiresAt,
+            processingStartedAt = processedAt,
+            exitedAt = exitedAt,
+            expiredAt = expiredAt,
+        )
+
+    companion object {
+        fun from(queueEntry: QueueEntry): QueueEntryEntity =
+            QueueEntryEntity(
+                id = queueEntry.id,
+                userId = queueEntry.userId,
+                token = queueEntry.token,
+                queuePosition = queueEntry.position,
+                status = QueueEntryEntityStatus.from(queueEntry.status),
+                expiresAt = queueEntry.expiresAt,
+                processedAt = queueEntry.processingStartedAt,
+                exitedAt = queueEntry.exitedAt,
+                expiredAt = queueEntry.expiredAt,
+            )
+    }
+}
+
+enum class QueueEntryEntityStatus {
+    READY,
+    PROCESSING,
+    EXITED,
+    EXPIRED,
+    ;
+
+    fun toQueueEntryStatus(): QueueEntryStatus =
+        when (this) {
+            READY -> QueueEntryStatus.WAITING
+            PROCESSING -> QueueEntryStatus.PROCESSING
+            EXITED -> QueueEntryStatus.EXITED
+            EXPIRED -> QueueEntryStatus.EXPIRED
+        }
+
+    companion object {
+        fun from(queueEntryStatus: QueueEntryStatus): QueueEntryEntityStatus =
+            when (queueEntryStatus) {
+                QueueEntryStatus.WAITING -> READY
+                QueueEntryStatus.PROCESSING -> PROCESSING
+                QueueEntryStatus.EXITED -> EXITED
+                QueueEntryStatus.EXPIRED -> EXPIRED
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ReservationEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/ReservationEntity.kt
@@ -1,0 +1,75 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Reservation
+import com.yuiyeong.ticketing.domain.model.ReservationStatus
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "reservation")
+class ReservationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val concertId: Long,
+    val concertEventId: Long,
+    val status: ReservationEntityStatus,
+    val totalSeats: Int,
+    val totalAmount: BigDecimal,
+    @OneToMany(mappedBy = "reservation")
+    val seatAllocations: List<SeatAllocationEntity> = listOf(),
+) : BaseEntity() {
+    fun toReservation(): Reservation =
+        Reservation(
+            id = id,
+            userId = userId,
+            concertId = concertId,
+            concertEventId = concertEventId,
+            status = status.toReservationStatus(),
+            totalSeats = totalSeats,
+            totalAmount = totalAmount,
+            createdAt = createdAt,
+        )
+
+    companion object {
+        fun from(reservation: Reservation): ReservationEntity =
+            ReservationEntity(
+                id = reservation.id,
+                userId = reservation.userId,
+                concertId = reservation.concertId,
+                concertEventId = reservation.concertEventId,
+                status = ReservationEntityStatus.from(reservation.status),
+                totalSeats = reservation.totalSeats,
+                totalAmount = reservation.totalAmount,
+            )
+    }
+}
+
+enum class ReservationEntityStatus {
+    PENDING,
+    CONFIRMED,
+    PAYMENT_FAILED,
+    ;
+
+    fun toReservationStatus(): ReservationStatus =
+        when (this) {
+            PENDING -> ReservationStatus.PENDING
+            CONFIRMED -> ReservationStatus.CONFIRMED
+            PAYMENT_FAILED -> ReservationStatus.PAYMENT_FAILED
+        }
+
+    companion object {
+        fun from(reservationStatus: ReservationStatus): ReservationEntityStatus =
+            when (reservationStatus) {
+                ReservationStatus.PENDING -> PENDING
+                ReservationStatus.CONFIRMED -> CONFIRMED
+                ReservationStatus.PAYMENT_FAILED -> PAYMENT_FAILED
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/SeatAllocationEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/SeatAllocationEntity.kt
@@ -1,0 +1,93 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.AllocationStatus
+import com.yuiyeong.ticketing.domain.model.SeatAllocation
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "seat_allocation")
+class SeatAllocationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val seatId: Long,
+    val seatPrice: BigDecimal,
+    val seatNumber: String,
+    val status: SeatAllocationEntityStatus,
+    val occupiedAt: ZonedDateTime?,
+    val expiredAt: ZonedDateTime?,
+    val reservedAt: ZonedDateTime?,
+) : BaseEntity() {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "occupation_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var occupation: OccupationEntity? = null
+        private set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    var reservation: ReservationEntity? = null
+        private set
+
+    fun toSeatAllocation(): SeatAllocation =
+        SeatAllocation(
+            id = id,
+            userId = userId,
+            seatId = seatId,
+            seatPrice = seatPrice,
+            seatNumber = seatNumber,
+            status = status.toAllocationStatus(),
+            occupiedAt = occupiedAt,
+            expiredAt = expiredAt,
+            reservedAt = reservedAt,
+        )
+
+    companion object {
+        fun from(seatAllocation: SeatAllocation): SeatAllocationEntity =
+            SeatAllocationEntity(
+                id = seatAllocation.id,
+                userId = seatAllocation.userId,
+                seatId = seatAllocation.seatId,
+                seatPrice = seatAllocation.seatPrice,
+                seatNumber = seatAllocation.seatNumber,
+                status = SeatAllocationEntityStatus.from(seatAllocation.status),
+                occupiedAt = seatAllocation.occupiedAt,
+                expiredAt = seatAllocation.expiredAt,
+                reservedAt = seatAllocation.reservedAt,
+            )
+    }
+}
+
+enum class SeatAllocationEntityStatus {
+    OCCUPIED,
+    EXPIRED,
+    RESERVED,
+    ;
+
+    fun toAllocationStatus(): AllocationStatus =
+        when (this) {
+            OCCUPIED -> AllocationStatus.OCCUPIED
+            EXPIRED -> AllocationStatus.EXPIRED
+            RESERVED -> AllocationStatus.RESERVED
+        }
+
+    companion object {
+        fun from(allocationStatus: AllocationStatus): SeatAllocationEntityStatus =
+            when (allocationStatus) {
+                AllocationStatus.OCCUPIED -> OCCUPIED
+                AllocationStatus.EXPIRED -> EXPIRED
+                AllocationStatus.RESERVED -> RESERVED
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/SeatEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/SeatEntity.kt
@@ -1,0 +1,41 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Seat
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "seat")
+class SeatEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val concertEventId: Long,
+    val seatNumber: String,
+    val price: BigDecimal,
+    val isAvailable: Boolean,
+) : BaseEntity() {
+    fun toSeat(): Seat =
+        Seat(
+            id = id,
+            concertEventId = concertEventId,
+            seatNumber = seatNumber,
+            price = price,
+            isAvailable = isAvailable,
+        )
+
+    companion object {
+        fun from(seat: Seat): SeatEntity =
+            SeatEntity(
+                id = seat.id,
+                concertEventId = seat.concertEventId,
+                seatNumber = seat.seatNumber,
+                price = seat.price,
+                isAvailable = seat.isAvailable,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/WalletEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/WalletEntity.kt
@@ -1,0 +1,37 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Wallet
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "wallet")
+class WalletEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val userId: Long,
+    val balance: BigDecimal,
+) : BaseEntity() {
+    fun toWallet(): Wallet =
+        Wallet(
+            id = this.id,
+            userId = this.userId,
+            balance = this.balance,
+            createdAt = this.createdAt,
+            updatedAt = this.updatedAt,
+        )
+
+    companion object {
+        fun from(wallet: Wallet): WalletEntity =
+            WalletEntity(
+                id = wallet.id,
+                userId = wallet.userId,
+                balance = wallet.balance,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/WalletTransactionEntity.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/entity/WalletTransactionEntity.kt
@@ -1,0 +1,63 @@
+package com.yuiyeong.ticketing.infrastructure.entity
+
+import com.yuiyeong.ticketing.domain.model.Transaction
+import com.yuiyeong.ticketing.domain.model.TransactionType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "wallet_transaction")
+class WalletTransactionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val walletId: Long,
+    val amount: BigDecimal,
+    @Enumerated(EnumType.STRING)
+    val type: WalletTransactionType,
+) : BaseEntity() {
+    fun toTransaction(): Transaction =
+        Transaction(
+            id = this.id,
+            walletId = this.walletId,
+            amount = this.amount,
+            type = this.type.toTransactionType(),
+            createdAt = createdAt,
+        )
+
+    companion object {
+        fun from(transaction: Transaction): WalletTransactionEntity =
+            WalletTransactionEntity(
+                id = transaction.id,
+                walletId = transaction.walletId,
+                amount = transaction.amount,
+                type = WalletTransactionType.from(transaction.type),
+            )
+    }
+}
+
+enum class WalletTransactionType {
+    CHARGED,
+    PAID,
+    ;
+
+    fun toTransactionType(): TransactionType =
+        when (this) {
+            CHARGED -> TransactionType.CHARGE
+            PAID -> TransactionType.PAYMENT
+        }
+
+    companion object {
+        fun from(type: TransactionType): WalletTransactionType =
+            when (type) {
+                TransactionType.CHARGE -> CHARGED
+                TransactionType.PAYMENT -> PAID
+            }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertEventJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertEventJpaRepository.kt
@@ -1,0 +1,30 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.ConcertEventEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
+import org.springframework.data.repository.query.Param
+import java.time.ZonedDateTime
+
+interface ConcertEventJpaRepository : JpaRepository<ConcertEventEntity, Long> {
+    @Query(
+        """ 
+        SELECT ce FROM ConcertEventEntity ce 
+        WHERE ce.concert.id = :concertId 
+        AND ce.reservationStartAt <= :moment 
+        AND :moment <= ce.reservationEndAt
+        """,
+    )
+    fun findAllWithinPeriodByConcertId(
+        @Param("concertId") concertId: Long,
+        @Param("moment") moment: ZonedDateTime,
+    ): List<ConcertEventEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    fun findOneWithLockById(id: Long): ConcertEventEntity?
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertEventRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertEventRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.ConcertEvent
+import com.yuiyeong.ticketing.domain.repository.ConcertEventRepository
+import com.yuiyeong.ticketing.infrastructure.entity.ConcertEventEntity
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+
+@Repository
+class ConcertEventRepositoryImpl(
+    private val concertEventJpaRepository: ConcertEventJpaRepository,
+) : ConcertEventRepository {
+    override fun save(concertEvent: ConcertEvent): ConcertEvent {
+        val entity = concertEventJpaRepository.save(ConcertEventEntity.from(concertEvent))
+        return entity.toConcertEvent()
+    }
+
+    override fun saveAll(concertEvents: List<ConcertEvent>): List<ConcertEvent> {
+        val entities = concertEventJpaRepository.saveAll(concertEvents.map { ConcertEventEntity.from(it) })
+        return entities.map { it.toConcertEvent() }
+    }
+
+    override fun findAllWithinPeriodBy(
+        concertId: Long,
+        moment: ZonedDateTime,
+    ): List<ConcertEvent> =
+        concertEventJpaRepository
+            .findAllWithinPeriodByConcertId(
+                concertId,
+                moment,
+            ).map { it.toConcertEvent() }
+
+    override fun findOneById(id: Long): ConcertEvent? = concertEventJpaRepository.findByIdOrNull(id)?.toConcertEvent()
+
+    override fun findOneByIdWithLock(id: Long): ConcertEvent? = concertEventJpaRepository.findOneWithLockById(id)?.toConcertEvent()
+
+    override fun deleteAll() = concertEventJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.ConcertEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ConcertJpaRepository : JpaRepository<ConcertEntity, Long>

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ConcertRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Concert
+import com.yuiyeong.ticketing.domain.repository.ConcertRepository
+import com.yuiyeong.ticketing.infrastructure.entity.ConcertEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class ConcertRepositoryImpl(
+    private val concertJpaRepository: ConcertJpaRepository,
+) : ConcertRepository {
+    override fun save(concert: Concert): Concert {
+        val concertEntity = concertJpaRepository.save(ConcertEntity.from(concert))
+        return concertEntity.toConcert()
+    }
+
+    override fun findAll(): List<Concert> = concertJpaRepository.findAll().map { it.toConcert() }
+
+    override fun deleteAll() = concertJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/OccupationJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/OccupationJpaRepository.kt
@@ -1,0 +1,32 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.OccupationEntity
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.ZonedDateTime
+
+interface OccupationJpaRepository : JpaRepository<OccupationEntity, Long> {
+    @EntityGraph(attributePaths = ["seatAllocations"])
+    @Query("SELECT o FROM OccupationEntity o WHERE o.id = :occupationId")
+    fun findOneById(
+        @Param("occupationId") occupationId: Long,
+    ): OccupationEntity?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = ["seatAllocations"])
+    @Query("SELECT o FROM OccupationEntity o WHERE o.id = :occupationId")
+    fun findOneWithLockById(
+        @Param("occupationId") occupationId: Long,
+    ): OccupationEntity?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = ["seatAllocations"])
+    @Query("SELECT o from OccupationEntity o WHERE o.expiresAt < :moment")
+    fun findAllWithLockByExpiresAtBefore(
+        @Param("moment") moment: ZonedDateTime,
+    ): List<OccupationEntity>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/OccupationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/OccupationRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Occupation
+import com.yuiyeong.ticketing.domain.repository.OccupationRepository
+import com.yuiyeong.ticketing.infrastructure.entity.OccupationEntity
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+
+@Repository
+class OccupationRepositoryImpl(
+    private val occupationJpaRepository: OccupationJpaRepository,
+) : OccupationRepository {
+    override fun save(occupation: Occupation): Occupation {
+        val occupationEntity = occupationJpaRepository.save(OccupationEntity.from(occupation))
+        return occupationEntity.toOccupation()
+    }
+
+    override fun saveAll(occupations: List<Occupation>): List<Occupation> {
+        val occupationEntities = occupations.map { OccupationEntity.from(it) }
+        return occupationJpaRepository.saveAll(occupationEntities).map { it.toOccupation() }
+    }
+
+    override fun findAllByExpiresAtBeforeWithLock(moment: ZonedDateTime): List<Occupation> =
+        occupationJpaRepository.findAllWithLockByExpiresAtBefore(moment).map {
+            it.toOccupation()
+        }
+
+    override fun findOneById(id: Long): Occupation? = occupationJpaRepository.findOneById(id)?.toOccupation()
+
+    override fun findOneByIdWithLock(id: Long): Occupation? = occupationJpaRepository.findOneWithLockById(id)?.toOccupation()
+
+    override fun deleteAll() = occupationJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/PaymentJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/PaymentJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.PaymentEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<PaymentEntity, Long> {
+    fun findAllByUserId(userId: Long): List<PaymentEntity>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/PaymentRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/PaymentRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Payment
+import com.yuiyeong.ticketing.domain.repository.PaymentRepository
+import com.yuiyeong.ticketing.infrastructure.entity.PaymentEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class PaymentRepositoryImpl(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    override fun save(payment: Payment): Payment {
+        val entity = paymentJpaRepository.save(PaymentEntity.from(payment))
+        return entity.toPayment()
+    }
+
+    override fun saveAll(payments: List<Payment>): List<Payment> {
+        val entities = paymentJpaRepository.saveAll(payments.map { PaymentEntity.from(it) })
+        return entities.map { it.toPayment() }
+    }
+
+    override fun findAllByUserId(userId: Long): List<Payment> = paymentJpaRepository.findAllByUserId(userId).map { it.toPayment() }
+
+    override fun deleteAll() = paymentJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/QueueEntryJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/QueueEntryJpaRepository.kt
@@ -1,0 +1,61 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.QueueEntryEntity
+import com.yuiyeong.ticketing.infrastructure.entity.QueueEntryEntityStatus
+import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.ZonedDateTime
+
+interface QueueEntryJpaRepository : JpaRepository<QueueEntryEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findOneWithLockById(id: Long): QueueEntryEntity?
+
+    fun findOneByToken(token: String): QueueEntryEntity?
+
+    @Query(
+        """
+        SELECT e FROM QueueEntryEntity e 
+        WHERE e.userId = :userId 
+        AND e.status in :statuses
+    """,
+    )
+    fun findAllByUserIdAndStatuses(
+        @Param("userId") userId: Long,
+        @Param("statuses") statuses: Array<QueueEntryEntityStatus>,
+    ): List<QueueEntryEntity>
+
+    @Query("SELECT e FROM QueueEntryEntity e WHERE e.status in :statuses")
+    fun findAllByStatuses(
+        @Param("statuses") statuses: Array<QueueEntryEntityStatus>,
+    ): List<QueueEntryEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT q FROM QueueEntryEntity q WHERE q.status = :status ORDER BY q.queuePosition ASC")
+    fun findAllByStatusOrderByPositionWithLock(
+        @Param("status") status: QueueEntryEntityStatus,
+        pageable: Pageable,
+    ): List<QueueEntryEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        SELECT e FROM QueueEntryEntity e 
+        WHERE e.status in :statuses
+        AND e.expiresAt < :moment
+    """,
+    )
+    fun findAllByStatusAndExpiresAtBeforeWithLock(
+        @Param("statuses") statuses: Array<QueueEntryEntityStatus>,
+        @Param("moment") moment: ZonedDateTime,
+    ): List<QueueEntryEntity>
+
+    @Query("SELECT MAX(q.queuePosition) FROM QueueEntryEntity q WHERE q.status = :status")
+    fun findLastPositionByStatus(status: QueueEntryEntityStatus): Long?
+
+    @Query("SELECT MIN(q.queuePosition) FROM QueueEntryEntity q WHERE q.status = :status")
+    fun findFirstPositionByStatus(status: QueueEntryEntityStatus): Long?
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/QueueEntryRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/QueueEntryRepositoryImpl.kt
@@ -1,0 +1,68 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+import com.yuiyeong.ticketing.domain.repository.QueueEntryRepository
+import com.yuiyeong.ticketing.infrastructure.entity.QueueEntryEntity
+import com.yuiyeong.ticketing.infrastructure.entity.QueueEntryEntityStatus
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+
+@Repository
+class QueueEntryRepositoryImpl(
+    private val queueEntryJpaRepository: QueueEntryJpaRepository,
+) : QueueEntryRepository {
+    override fun save(entry: QueueEntry): QueueEntry {
+        val entity = queueEntryJpaRepository.save(QueueEntryEntity.from(entry))
+        return entity.toQueueEntry()
+    }
+
+    override fun saveAll(entries: List<QueueEntry>): List<QueueEntry> {
+        val entities = queueEntryJpaRepository.saveAll(entries.map { QueueEntryEntity.from(it) })
+        return entities.map { it.toQueueEntry() }
+    }
+
+    override fun findOneByToken(token: String): QueueEntry? = queueEntryJpaRepository.findOneByToken(token)?.toQueueEntry()
+
+    override fun findOneByIdWithLock(id: Long): QueueEntry? = queueEntryJpaRepository.findOneWithLockById(id)?.toQueueEntry()
+
+    override fun findAllByUserIdWithStatus(
+        userId: Long,
+        vararg status: QueueEntryStatus,
+    ): List<QueueEntry> {
+        val entityStatuses = status.map { QueueEntryEntityStatus.from(it) }.toTypedArray()
+        val entities = queueEntryJpaRepository.findAllByUserIdAndStatuses(userId, entityStatuses)
+        return entities.map { it.toQueueEntry() }
+    }
+
+    override fun findAllByStatus(vararg status: QueueEntryStatus): List<QueueEntry> {
+        val entityStatuses = status.map { QueueEntryEntityStatus.from(it) }.toTypedArray()
+        val entities = queueEntryJpaRepository.findAllByStatuses(entityStatuses)
+        return entities.map { it.toQueueEntry() }
+    }
+
+    override fun findAllByStatusOrderByPositionWithLock(
+        status: QueueEntryStatus,
+        limit: Int,
+    ): List<QueueEntry> {
+        val limitPageable = PageRequest.of(0, limit)
+        val entities = queueEntryJpaRepository.findAllByStatusOrderByPositionWithLock(QueueEntryEntityStatus.from(status), limitPageable)
+        return entities.map { it.toQueueEntry() }
+    }
+
+    override fun findAllByExpiresAtBeforeAndStatusWithLock(
+        moment: ZonedDateTime,
+        vararg status: QueueEntryStatus,
+    ): List<QueueEntry> {
+        val entityStatuses = status.map { QueueEntryEntityStatus.from(it) }.toTypedArray()
+        val entities = queueEntryJpaRepository.findAllByStatusAndExpiresAtBeforeWithLock(entityStatuses, moment)
+        return entities.map { it.toQueueEntry() }
+    }
+
+    override fun findLastWaitingPosition(): Long? = queueEntryJpaRepository.findLastPositionByStatus(QueueEntryEntityStatus.READY)
+
+    override fun findFirstWaitingPosition(): Long? = queueEntryJpaRepository.findFirstPositionByStatus(QueueEntryEntityStatus.READY)
+
+    override fun deleteAll() = queueEntryJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ReservationJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ReservationJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.ReservationEntity
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+
+interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findOneWithLockById(id: Long): ReservationEntity?
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ReservationRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/ReservationRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Reservation
+import com.yuiyeong.ticketing.domain.repository.ReservationRepository
+import com.yuiyeong.ticketing.infrastructure.entity.ReservationEntity
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReservationRepositoryImpl(
+    private val reservationJpaRepository: ReservationJpaRepository,
+) : ReservationRepository {
+    override fun save(reservation: Reservation): Reservation {
+        val entity = reservationJpaRepository.save(ReservationEntity.from(reservation))
+        return entity.toReservation()
+    }
+
+    override fun findOneById(id: Long): Reservation? = reservationJpaRepository.findByIdOrNull(id)?.toReservation()
+
+    override fun findOneByIdWithLock(id: Long): Reservation? = reservationJpaRepository.findOneWithLockById(id)?.toReservation()
+
+    override fun deleteAll() = reservationJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/SeatJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/SeatJpaRepository.kt
@@ -1,0 +1,31 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.SeatEntity
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
+    @Query("SELECT s FROM SeatEntity s WHERE s.id IN :ids")
+    fun findAllByIds(
+        @Param("ids") ids: List<Long>,
+    ): List<SeatEntity>
+
+    @Query("SELECT s FROM SeatEntity s WHERE s.id IN :ids AND s.isAvailable = true")
+    fun findAllAvailableByIds(
+        @Param("ids") ids: List<Long>,
+    ): List<SeatEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM SeatEntity s WHERE s.id IN :ids AND s.isAvailable = true")
+    fun findAllAvailableWithLockByIds(
+        @Param("ids") ids: List<Long>,
+    ): List<SeatEntity>
+
+    @Query("SELECT s FROM SeatEntity s WHERE s.concertEventId = :concertEventId AND s.isAvailable = true")
+    fun findAllAvailableByConcertEventId(
+        @Param("concertEventId") concertEventId: Long,
+    ): List<SeatEntity>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/SeatRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/SeatRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Seat
+import com.yuiyeong.ticketing.domain.repository.SeatRepository
+import com.yuiyeong.ticketing.infrastructure.entity.SeatEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class SeatRepositoryImpl(
+    private val seatJpaRepository: SeatJpaRepository,
+) : SeatRepository {
+    override fun save(seat: Seat): Seat {
+        val seatEntity = seatJpaRepository.save(SeatEntity.from(seat))
+        return seatEntity.toSeat()
+    }
+
+    override fun findAllByIds(ids: List<Long>): List<Seat> {
+        val seatEntities = seatJpaRepository.findAllByIds(ids)
+        return seatEntities.map { it.toSeat() }
+    }
+
+    override fun findAllAvailableByIds(ids: List<Long>): List<Seat> {
+        val seatEntities = seatJpaRepository.findAllAvailableByIds(ids)
+        return seatEntities.map { it.toSeat() }
+    }
+
+    override fun findAllAvailableByIdsWithLock(ids: List<Long>): List<Seat> {
+        val seatEntities = seatJpaRepository.findAllAvailableByIds(ids)
+        return seatEntities.map { it.toSeat() }
+    }
+
+    override fun findAllAvailableByConcertEventId(concertEventId: Long): List<Seat> {
+        val seatEntities = seatJpaRepository.findAllAvailableByConcertEventId(concertEventId)
+        return seatEntities.map { it.toSeat() }
+    }
+
+    override fun saveAll(seats: List<Seat>): List<Seat> {
+        val seatEntities = seatJpaRepository.saveAll(seats.map { SeatEntity.from(it) })
+        return seatEntities.map { it.toSeat() }
+    }
+
+    override fun deleteAll() = seatJpaRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/TransactionJapRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/TransactionJapRepository.kt
@@ -1,0 +1,6 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.WalletTransactionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TransactionJapRepository : JpaRepository<WalletTransactionEntity, Long>

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/TransactionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/TransactionRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Transaction
+import com.yuiyeong.ticketing.domain.repository.TransactionRepository
+import com.yuiyeong.ticketing.infrastructure.entity.WalletTransactionEntity
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class TransactionRepositoryImpl(
+    private val transactionJapRepository: TransactionJapRepository,
+) : TransactionRepository {
+    override fun save(transaction: Transaction): Transaction {
+        val walletTransactionEntity = transactionJapRepository.save(WalletTransactionEntity.from(transaction))
+        return walletTransactionEntity.toTransaction()
+    }
+
+    override fun findOneById(id: Long): Transaction? = transactionJapRepository.findByIdOrNull(id)?.toTransaction()
+
+    override fun deleteAll() = transactionJapRepository.deleteAll()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/WalletJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/WalletJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.infrastructure.entity.WalletEntity
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+
+interface WalletJpaRepository : JpaRepository<WalletEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findOneWithLockByUserId(userId: Long): WalletEntity?
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/WalletRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/repository/WalletRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.yuiyeong.ticketing.infrastructure.repository
+
+import com.yuiyeong.ticketing.domain.model.Wallet
+import com.yuiyeong.ticketing.domain.repository.WalletRepository
+import com.yuiyeong.ticketing.infrastructure.entity.WalletEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class WalletRepositoryImpl(
+    private val walletJpaRepository: WalletJpaRepository,
+) : WalletRepository {
+    override fun save(wallet: Wallet): Wallet {
+        val walletEntity = walletJpaRepository.save(WalletEntity.from(wallet))
+        return walletEntity.toWallet()
+    }
+
+    override fun findOneByUserIdWithLock(userId: Long): Wallet? = walletJpaRepository.findOneWithLockByUserId(userId)?.toWallet()
+
+    override fun deleteAll() = walletJpaRepository.deleteAll()
+}


### PR DESCRIPTION
## 회고
- [중간 리뷰](https://github.com/yuiyeong/ticketing-service/blob/main/docs/half-review.md)

## BaseEntity
- createAt 과 updateAt 을 넣기위해 만든 `MappedSuperclass`

## Entities
- 도메인 모델과 구별될 수 있도록, `Entity` 라는 postfix 를 붙였습니다.
- primary constructor 에서, persistance 관련  annotation 을 모두 처리하도록 했습니다.
- 도메인 모델과의 Mapper 함수를 Entity 에 구현했습니다.

## 도메인 repository 의 구현체 추가
- JpaRepository 를 이용하여, 도메인 repository 를 구현하였습니다.

## 리뷰포인트
- type 이나 status 를 표현한 enum class 에서 mapper 함수를 만들어 주었는데, enum 의 기존 mapper 함수와 달라 이질감이 느껴집니다. 리뷰 부탁드립니다.