### PR TITLE
Feat: 도메인 서비스 추가

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/application/service/TicketingExceptionService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/service/TicketingExceptionService.kt
@@ -1,0 +1,33 @@
+package com.yuiyeong.ticketing.application.service
+
+import com.yuiyeong.ticketing.application.dto.ErrorStatusCode
+import com.yuiyeong.ticketing.application.dto.TicketingError
+import com.yuiyeong.ticketing.domain.exception.BadRequestException
+import com.yuiyeong.ticketing.domain.exception.ErrorCode
+import com.yuiyeong.ticketing.domain.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class TicketingExceptionService {
+    fun handleException(e: Exception): TicketingError =
+        when (e) {
+            is BadRequestException ->
+                TicketingError(
+                    ErrorStatusCode.BAD_REQUEST,
+                    e.errorCode.name.lowercase(),
+                    e.errorCode.message,
+                )
+            is NotFoundException ->
+                TicketingError(
+                    ErrorStatusCode.NOT_FOUND,
+                    e.errorCode.name.lowercase(),
+                    e.errorCode.message,
+                )
+            else ->
+                TicketingError(
+                    ErrorStatusCode.INTERNAL_ERROR,
+                    ErrorCode.INTERNAL_SERVER_ERROR.name.lowercase(),
+                    ErrorCode.INTERNAL_SERVER_ERROR.message,
+                )
+        }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/ConcertEventService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/ConcertEventService.kt
@@ -1,0 +1,32 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.exception.ConcertEventNotFoundException
+import com.yuiyeong.ticketing.domain.model.ConcertEvent
+import com.yuiyeong.ticketing.domain.repository.ConcertEventRepository
+import com.yuiyeong.ticketing.domain.repository.SeatRepository
+import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
+
+@Service
+class ConcertEventService(
+    private val concertEventRepository: ConcertEventRepository,
+    private val seatRepository: SeatRepository,
+) {
+    fun getAvailableEvents(concertId: Long): List<ConcertEvent> {
+        val now = ZonedDateTime.now().asUtc
+        return concertEventRepository.findAllWithinPeriodBy(concertId, now)
+    }
+
+    fun getConcertEvent(concertEventId: Long): ConcertEvent {
+        val concertEvent = concertEventRepository.findOneById(concertEventId) ?: throw ConcertEventNotFoundException()
+        return concertEvent
+    }
+
+    fun refreshAvailableSeats(concertEventId: Long) {
+        val concertEvent = concertEventRepository.findOneByIdWithLock(concertEventId) ?: throw ConcertEventNotFoundException()
+        val seats = seatRepository.findAllAvailableByConcertEventId(concertEventId)
+        concertEvent.recalculateAvailableSeatCount(seats)
+        concertEventRepository.save(concertEvent)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/OccupationService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/OccupationService.kt
@@ -1,0 +1,49 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.exception.OccupationNotFoundException
+import com.yuiyeong.ticketing.domain.exception.SeatUnavailableException
+import com.yuiyeong.ticketing.domain.model.Occupation
+import com.yuiyeong.ticketing.domain.repository.OccupationRepository
+import com.yuiyeong.ticketing.domain.repository.SeatRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
+
+@Service
+class OccupationService(
+    @Value("\${config.valid-occupied-duration}") private val validOccupiedDuration: Long,
+    private val occupationRepository: OccupationRepository,
+    private val seatRepository: SeatRepository,
+) {
+    fun createOccupation(
+        userId: Long,
+        concertEventId: Long,
+        seatIds: List<Long>,
+    ): Occupation {
+        val seats = seatRepository.findAllAvailableByIds(seatIds)
+
+        if (seats.count() != seatIds.count()) throw SeatUnavailableException()
+
+        val occupation = Occupation.create(userId, concertEventId, seats, validOccupiedDuration)
+        return occupationRepository.save(occupation)
+    }
+
+    fun release(
+        userId: Long,
+        occupationId: Long,
+    ): Occupation {
+        val occupation =
+            occupationRepository.findOneByIdWithLock(occupationId) ?: throw OccupationNotFoundException()
+        val now = ZonedDateTime.now().asUtc
+        occupation.release(now)
+        return occupationRepository.save(occupation)
+    }
+
+    fun expireOverdueOccupations(): List<Occupation> {
+        val current = ZonedDateTime.now().asUtc
+        val occupations = occupationRepository.findAllByExpiresAtBeforeWithLock(current)
+        occupations.forEach { it.expire() }
+        return occupationRepository.saveAll(occupations)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/PaymentService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/PaymentService.kt
@@ -1,0 +1,34 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.domain.exception.ReservationNotFoundException
+import com.yuiyeong.ticketing.domain.exception.TransactionNotFoundException
+import com.yuiyeong.ticketing.domain.model.Payment
+import com.yuiyeong.ticketing.domain.repository.PaymentRepository
+import com.yuiyeong.ticketing.domain.repository.ReservationRepository
+import com.yuiyeong.ticketing.domain.repository.TransactionRepository
+import org.springframework.stereotype.Service
+
+@Service
+class PaymentService(
+    private val reservationRepository: ReservationRepository,
+    private val transactionRepository: TransactionRepository,
+    private val paymentRepository: PaymentRepository,
+) {
+    fun create(
+        userId: Long,
+        reservationId: Long,
+        transactionId: Long?,
+        failureReason: String?,
+    ): Payment {
+        val reservation = reservationRepository.findOneById(reservationId) ?: throw ReservationNotFoundException()
+        val transaction =
+            transactionId?.let { id ->
+                transactionRepository.findOneById(id) ?: throw TransactionNotFoundException()
+            }
+
+        val payment = Payment.create(userId, reservation, transaction, failureReason)
+        return paymentRepository.save(payment)
+    }
+
+    fun getHistory(userId: Long): List<Payment> = paymentRepository.findAllByUserId(userId)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/QueueService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/QueueService.kt
@@ -1,0 +1,80 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+import com.yuiyeong.ticketing.domain.repository.QueueEntryRepository
+import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
+
+@Service
+class QueueService(
+    private val entryRepository: QueueEntryRepository,
+) {
+    fun getFirstWaitingPosition(): Long = entryRepository.findFirstWaitingPosition() ?: 0
+
+    fun enter(
+        userId: Long,
+        token: String,
+        enteredAt: ZonedDateTime,
+        expiresAt: ZonedDateTime,
+    ): QueueEntry {
+        val lastPosition = entryRepository.findLastWaitingPosition() ?: 0
+        val activeSize = entryRepository.findAllByStatus(QueueEntryStatus.PROCESSING).size
+        val status = if (activeSize < MAX_ACTIVE_ENTRIES) QueueEntryStatus.PROCESSING else QueueEntryStatus.WAITING
+        val newPosition = if (status == QueueEntryStatus.WAITING) lastPosition + 1 else 0
+
+        val queueEntry = QueueEntry.create(userId, newPosition, token, status, enteredAt, expiresAt)
+        return entryRepository.save(queueEntry)
+    }
+
+    fun exit(entryId: Long): QueueEntry {
+        val entry = entryRepository.findOneByIdWithLock(entryId) ?: throw InvalidTokenException()
+        val current = ZonedDateTime.now().asUtc
+        entry.exit(current)
+        return entryRepository.save(entry)
+    }
+
+    fun getEntry(token: String?): QueueEntry {
+        if (token == null) throw InvalidTokenException()
+        return entryRepository.findOneByToken(token) ?: throw InvalidTokenException()
+    }
+
+    fun activateWaitingEntries(): List<QueueEntry> {
+        val alreadyActivatedEntries = entryRepository.findAllByStatus(QueueEntryStatus.PROCESSING)
+        val newActivatingCount = MAX_ACTIVE_ENTRIES - alreadyActivatedEntries.count()
+        if (newActivatingCount <= 0) {
+            return emptyList() // there is no one to be activated.
+        }
+
+        val current = ZonedDateTime.now().asUtc
+        val waitingEntries =
+            entryRepository.findAllByStatusOrderByPositionWithLock(QueueEntryStatus.WAITING, newActivatingCount)
+        waitingEntries.forEach { it.process(current) }
+
+        return entryRepository.saveAll(waitingEntries)
+    }
+
+    fun expireOverdueEntries(): List<QueueEntry> {
+        val current = ZonedDateTime.now().asUtc
+        val entries =
+            entryRepository.findAllByExpiresAtBeforeAndStatusWithLock(
+                current,
+                QueueEntryStatus.PROCESSING,
+                QueueEntryStatus.WAITING,
+            )
+        entries.forEach { it.expire(current) }
+        return entryRepository.saveAll(entries)
+    }
+
+    fun dequeueExistingEntries(userId: Long) {
+        entryRepository
+            .findAllByUserIdWithStatus(userId, QueueEntryStatus.PROCESSING, QueueEntryStatus.WAITING)
+            .forEach { exit(it.id) }
+    }
+
+    companion object {
+        const val MAX_ACTIVE_ENTRIES = 10 // 최대 10 명까지 작업 가능함
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/ReservationService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/ReservationService.kt
@@ -1,0 +1,44 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.exception.ConcertEventNotFoundException
+import com.yuiyeong.ticketing.domain.exception.OccupationNotFoundException
+import com.yuiyeong.ticketing.domain.exception.ReservationNotFoundException
+import com.yuiyeong.ticketing.domain.model.Reservation
+import com.yuiyeong.ticketing.domain.repository.ConcertEventRepository
+import com.yuiyeong.ticketing.domain.repository.OccupationRepository
+import com.yuiyeong.ticketing.domain.repository.ReservationRepository
+import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
+
+@Service
+class ReservationService(
+    private val reservationRepository: ReservationRepository,
+    private val concertEventRepository: ConcertEventRepository,
+    private val occupationRepository: OccupationRepository,
+) {
+    fun reserve(
+        userId: Long,
+        concertEventId: Long,
+        occupationId: Long,
+    ): Reservation {
+        val concertEvent = concertEventRepository.findOneById(concertEventId) ?: throw ConcertEventNotFoundException()
+        concertEvent.verifyWithinReservationPeriod(ZonedDateTime.now().asUtc)
+
+        val occupation = occupationRepository.findOneById(occupationId) ?: throw OccupationNotFoundException()
+
+        val reservation = Reservation.create(userId, concertEvent, occupation.allocations)
+        return reservationRepository.save(reservation)
+    }
+
+    fun getReservation(reservationId: Long): Reservation {
+        val reservation = reservationRepository.findOneById(reservationId) ?: throw ReservationNotFoundException()
+        return reservation
+    }
+
+    fun confirm(reservationId: Long): Reservation {
+        val reservation = reservationRepository.findOneByIdWithLock(reservationId) ?: throw ReservationNotFoundException()
+        reservation.confirm()
+        return reservationRepository.save(reservation)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/SeatService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/SeatService.kt
@@ -1,0 +1,23 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.domain.exception.SeatUnavailableException
+import com.yuiyeong.ticketing.domain.model.Seat
+import com.yuiyeong.ticketing.domain.repository.SeatRepository
+import org.springframework.stereotype.Service
+
+@Service
+class SeatService(
+    private val seatRepository: SeatRepository,
+) {
+    fun getAvailableSeats(concertEventId: Long): List<Seat> = seatRepository.findAllAvailableByConcertEventId(concertEventId)
+
+    fun occupy(seatIds: List<Long>): List<Seat> {
+        if (seatIds.isEmpty()) throw SeatUnavailableException()
+
+        val seats = seatRepository.findAllAvailableByIdsWithLock(seatIds)
+        if (seats.count() != seatIds.count()) throw SeatUnavailableException()
+
+        seats.forEach { it.makeUnavailable() }
+        return seatRepository.saveAll(seats)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/TokenService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/TokenService.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import java.time.ZonedDateTime
+
+interface TokenService {
+    fun generateToken(
+        userId: Long,
+        issuedAt: ZonedDateTime,
+        expiresAt: ZonedDateTime,
+    ): String
+
+    fun validateToken(token: String): QueueEntry
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/WalletService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/WalletService.kt
@@ -1,0 +1,44 @@
+package com.yuiyeong.ticketing.domain.service
+
+import com.yuiyeong.ticketing.domain.exception.WalletNotFoundException
+import com.yuiyeong.ticketing.domain.model.Transaction
+import com.yuiyeong.ticketing.domain.model.TransactionType
+import com.yuiyeong.ticketing.domain.model.Wallet
+import com.yuiyeong.ticketing.domain.repository.TransactionRepository
+import com.yuiyeong.ticketing.domain.repository.WalletRepository
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+@Service
+class WalletService(
+    private val walletRepository: WalletRepository,
+    private val transactionRepository: TransactionRepository,
+) {
+    fun getUserWallet(userId: Long): Wallet = walletRepository.findOneByUserIdWithLock(userId) ?: throw WalletNotFoundException()
+
+    fun charge(
+        userId: Long,
+        amount: BigDecimal,
+    ) = createTransaction(userId, amount, TransactionType.CHARGE)
+
+    fun pay(
+        userId: Long,
+        amount: BigDecimal,
+    ) = createTransaction(userId, amount, TransactionType.PAYMENT)
+
+    private fun createTransaction(
+        userId: Long,
+        amount: BigDecimal,
+        type: TransactionType,
+    ): Transaction {
+        val wallet = getUserWallet(userId)
+        val transaction = transactionRepository.save(Transaction.create(wallet, amount, type))
+
+        when (type) {
+            TransactionType.CHARGE -> wallet.charge(amount)
+            TransactionType.PAYMENT -> wallet.pay(amount)
+        }
+        walletRepository.save(wallet)
+        return transaction
+    }
+}


### PR DESCRIPTION
## 도메인 서비스 추가

- domain.service 패키지에 속하도록 했습니다.
- 최소한의 정보만 parameter 로 받아서, service 의 함수안에서 대부분 처리할 수 있도록 작성하려고 했습니다.
- 반환은 항상 도메인 모델을 반환하도록 했습니다.
- `@Transactional `을 붙이지 않았습니다. 
- 다음 Service 들을 구현했습니다.
    - ConcertEventService
    - OccupationService
    - PaymentService
    - QueueService
    - ReservationService
    - SeatService
    - TokenService
    - WalletService

### 리뷰 포인트
- `@Transactional` 이 없는데, Service 를 사용하는 쪽에서 Transaction 을 관리할 수 있도록 하고 싶었습니다.