### PR TITLE
Feat: UseCase 추가

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/ConcertEventResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/ConcertEventResult.kt
@@ -1,0 +1,21 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.ConcertEvent
+import com.yuiyeong.ticketing.domain.vo.DateTimeRange
+
+data class ConcertEventResult(
+    val id: Long,
+    val venue: String,
+    val reservationPeriod: DateTimeRange,
+    val performanceSchedule: DateTimeRange,
+) {
+    companion object {
+        fun from(concertEvent: ConcertEvent): ConcertEventResult =
+            ConcertEventResult(
+                concertEvent.id,
+                concertEvent.venue,
+                concertEvent.reservationPeriod,
+                concertEvent.performanceSchedule,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/OccupationResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/OccupationResult.kt
@@ -1,0 +1,24 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.Occupation
+import com.yuiyeong.ticketing.domain.model.OccupationStatus
+import java.time.ZonedDateTime
+
+data class OccupationResult(
+    val id: Long,
+    val userId: Long,
+    val seatId: Long,
+    val status: OccupationStatus,
+    val expiresAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(occupation: Occupation): OccupationResult =
+            OccupationResult(
+                occupation.id,
+                occupation.userId,
+                occupation.allocations[0].seatId,
+                occupation.status,
+                occupation.expiresAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/PaymentResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/PaymentResult.kt
@@ -1,0 +1,27 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.Payment
+import com.yuiyeong.ticketing.domain.model.PaymentStatus
+import java.math.BigDecimal
+import java.time.ZonedDateTime
+
+data class PaymentResult(
+    val id: Long,
+    val reservationId: Long,
+    val amount: BigDecimal,
+    val status: PaymentStatus,
+    val failureReason: String?,
+    val createdAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(payment: Payment): PaymentResult =
+            PaymentResult(
+                payment.id,
+                payment.reservationId,
+                payment.amount,
+                payment.status,
+                payment.failureReason,
+                payment.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/QueueEntryResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/QueueEntryResult.kt
@@ -1,0 +1,27 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.QueueEntry
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+
+data class QueueEntryResult(
+    val id: Long,
+    val userId: Long,
+    val token: String,
+    val position: Long,
+    val status: QueueEntryStatus,
+    val estimatedWaitingTime: Long,
+) {
+    companion object {
+        fun from(
+            entry: QueueEntry,
+            waitingPositionOffset: Long = 0,
+        ) = QueueEntryResult(
+            id = entry.id,
+            userId = entry.userId,
+            token = entry.token,
+            position = entry.calculateRelativePosition(waitingPositionOffset),
+            status = entry.status,
+            estimatedWaitingTime = entry.calculateEstimatedWaitingTime(waitingPositionOffset),
+        )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/ReservationResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/ReservationResult.kt
@@ -1,0 +1,35 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.ConcertEvent
+import com.yuiyeong.ticketing.domain.model.Reservation
+import com.yuiyeong.ticketing.domain.model.ReservationStatus
+import java.math.BigDecimal
+import java.time.ZonedDateTime
+
+data class ReservationResult(
+    val id: Long,
+    val userId: Long,
+    val concertVenue: String,
+    val concertPerformanceStartAt: ZonedDateTime,
+    val status: ReservationStatus,
+    val totalSeats: Int,
+    val totalAmount: BigDecimal,
+    val createdAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(
+            concertEvent: ConcertEvent,
+            reservation: Reservation,
+        ): ReservationResult =
+            ReservationResult(
+                reservation.id,
+                reservation.userId,
+                concertEvent.venue,
+                concertEvent.performanceSchedule.start,
+                reservation.status,
+                reservation.totalSeats,
+                reservation.totalAmount,
+                reservation.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/SeatResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/SeatResult.kt
@@ -1,0 +1,15 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.Seat
+import java.math.BigDecimal
+
+data class SeatResult(
+    val id: Long,
+    val seatNumber: String,
+    val price: BigDecimal,
+    val isAvailable: Boolean,
+) {
+    companion object {
+        fun from(seat: Seat): SeatResult = SeatResult(seat.id, seat.seatNumber, seat.price, seat.isAvailable)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/WalletResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/WalletResult.kt
@@ -1,0 +1,13 @@
+package com.yuiyeong.ticketing.application.dto
+
+import com.yuiyeong.ticketing.domain.model.Wallet
+import java.math.BigDecimal
+
+data class WalletResult(
+    val userId: Long,
+    val balance: BigDecimal,
+) {
+    companion object {
+        fun from(wallet: Wallet): WalletResult = WalletResult(wallet.userId, wallet.balance)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableConcertEventsUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableConcertEventsUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.concert
+
+import com.yuiyeong.ticketing.application.dto.ConcertEventResult
+
+interface GetAvailableConcertEventsUseCase {
+    fun execute(concertId: Long): List<ConcertEventResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableConcertEventsUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableConcertEventsUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.application.usecase.concert
+
+import com.yuiyeong.ticketing.application.dto.ConcertEventResult
+import com.yuiyeong.ticketing.domain.service.ConcertEventService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GetAvailableConcertEventsUseCaseImpl(
+    private val concertEventService: ConcertEventService,
+) : GetAvailableConcertEventsUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(concertId: Long): List<ConcertEventResult> {
+        val concertEvents = concertEventService.getAvailableEvents(concertId)
+        return concertEvents.map { ConcertEventResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableSeatsUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableSeatsUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.concert
+
+import com.yuiyeong.ticketing.application.dto.SeatResult
+
+interface GetAvailableSeatsUseCase {
+    fun execute(concertEventId: Long): List<SeatResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableSeatsUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/concert/GetAvailableSeatsUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.application.usecase.concert
+
+import com.yuiyeong.ticketing.application.dto.SeatResult
+import com.yuiyeong.ticketing.domain.service.SeatService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GetAvailableSeatsUseCaseImpl(
+    private val seatService: SeatService,
+) : GetAvailableSeatsUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(concertEventId: Long): List<SeatResult> {
+        val seats = seatService.getAvailableSeats(concertEventId)
+        return seats.map { SeatResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/GetPaymentListUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/GetPaymentListUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.payment
+
+import com.yuiyeong.ticketing.application.dto.PaymentResult
+
+interface GetPaymentListUseCase {
+    fun execute(userId: Long): List<PaymentResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/GetPaymentListUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/GetPaymentListUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.application.usecase.payment
+
+import com.yuiyeong.ticketing.application.dto.PaymentResult
+import com.yuiyeong.ticketing.domain.service.PaymentService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GetPaymentListUseCaseImpl(
+    private val paymentService: PaymentService,
+) : GetPaymentListUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long): List<PaymentResult> = paymentService.getHistory(userId).map { PaymentResult.from(it) }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/PayUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/PayUseCase.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.application.usecase.payment
+
+import com.yuiyeong.ticketing.application.dto.PaymentResult
+
+interface PayUseCase {
+    fun execute(
+        userId: Long,
+        queueEntryId: Long,
+        reservationId: Long,
+    ): PaymentResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/PayUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/payment/PayUseCaseImpl.kt
@@ -1,0 +1,49 @@
+package com.yuiyeong.ticketing.application.usecase.payment
+
+import com.yuiyeong.ticketing.application.dto.PaymentResult
+import com.yuiyeong.ticketing.domain.model.Transaction
+import com.yuiyeong.ticketing.domain.service.PaymentService
+import com.yuiyeong.ticketing.domain.service.QueueService
+import com.yuiyeong.ticketing.domain.service.ReservationService
+import com.yuiyeong.ticketing.domain.service.WalletService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PayUseCaseImpl(
+    private val reservationService: ReservationService,
+    private val walletService: WalletService,
+    private val paymentService: PaymentService,
+    private val queueService: QueueService,
+) : PayUseCase {
+    @Transactional
+    override fun execute(
+        userId: Long,
+        queueEntryId: Long,
+        reservationId: Long,
+    ): PaymentResult {
+        val reservation = reservationService.getReservation(reservationId)
+
+        // 결제 시도
+        var transaction: Transaction? = null
+        var failureReason: String? = null
+        runCatching {
+            walletService.pay(userId, reservation.totalAmount)
+        }.onSuccess {
+            transaction = it
+        }.onFailure { exception ->
+            failureReason = exception.message
+        }
+
+        // 결제 결과로 내역 만들기
+        val payment = paymentService.create(userId, reservation.id, transaction?.id, failureReason)
+
+        // reservation 의 상태를 완료로 변경
+        reservationService.confirm(reservation.id)
+
+        // queue 에서 entry 제거
+        queueService.exit(queueEntryId)
+
+        return PaymentResult.from(payment)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+interface ActivateWaitingEntriesUseCase {
+    fun execute(): List<QueueEntryResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.domain.service.QueueService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ActivateWaitingEntriesUseCaseImpl(
+    private val queueService: QueueService,
+) : ActivateWaitingEntriesUseCase {
+    @Transactional
+    override fun execute(): List<QueueEntryResult> = queueService.activateWaitingEntries().map { QueueEntryResult.from(it) }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+interface EnterQueueUseCase {
+    fun execute(userId: Long): QueueEntryResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCaseImpl.kt
@@ -1,0 +1,32 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.service.QueueService
+import com.yuiyeong.ticketing.domain.service.TokenService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZonedDateTime
+
+@Component
+class EnterQueueUseCaseImpl(
+    private val queueService: QueueService,
+    private val tokenService: TokenService,
+) : EnterQueueUseCase {
+    @Transactional
+    override fun execute(userId: Long): QueueEntryResult {
+        // 기존에 발급 받은 token 이 있다면, 대기열에 제거
+        queueService.dequeueExistingEntries(userId)
+
+        val enteredAt = ZonedDateTime.now().asUtc
+        val expiresAt = enteredAt.plusMinutes(EXPIRATION_MINUTES)
+        val token = tokenService.generateToken(userId, enteredAt, expiresAt)
+        val entry = queueService.enter(userId, token, enteredAt, expiresAt)
+        val positionOffset = queueService.getFirstWaitingPosition()
+        return QueueEntryResult.from(entry, positionOffset)
+    }
+
+    companion object {
+        const val EXPIRATION_MINUTES = 60L // 60분 뒤 만료
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ExpireWaitingEntryUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ExpireWaitingEntryUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+interface ExpireWaitingEntryUseCase {
+    fun execute(): List<QueueEntryResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ExpireWaitingEntryUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ExpireWaitingEntryUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.domain.service.QueueService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ExpireWaitingEntryUseCaseImpl(
+    private val queueService: QueueService,
+) : ExpireWaitingEntryUseCase {
+    @Transactional
+    override fun execute(): List<QueueEntryResult> = queueService.expireOverdueEntries().map { QueueEntryResult.from(it) }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ExpireOccupationsUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ExpireOccupationsUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.OccupationResult
+
+interface ExpireOccupationsUseCase {
+    fun execute(): List<OccupationResult>
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ExpireOccupationsUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ExpireOccupationsUseCaseImpl.kt
@@ -1,0 +1,21 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.OccupationResult
+import com.yuiyeong.ticketing.domain.service.ConcertEventService
+import com.yuiyeong.ticketing.domain.service.OccupationService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ExpireOccupationsUseCaseImpl(
+    private val occupationService: OccupationService,
+    private val concertEventService: ConcertEventService,
+) : ExpireOccupationsUseCase {
+    @Transactional
+    override fun execute(): List<OccupationResult> {
+        val occupations = occupationService.expireOverdueOccupations()
+        val concertEventIds = occupations.map { it.concertEventId }.distinct()
+        concertEventIds.forEach { concertEventService.refreshAvailableSeats(it) }
+        return occupations.map { OccupationResult.from(it) }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/OccupySeatUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/OccupySeatUseCase.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.OccupationResult
+
+interface OccupySeatUseCase {
+    fun execute(
+        userId: Long,
+        concertEventId: Long,
+        seatId: Long,
+    ): OccupationResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/OccupySeatUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/OccupySeatUseCaseImpl.kt
@@ -1,0 +1,35 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.OccupationResult
+import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.service.ConcertEventService
+import com.yuiyeong.ticketing.domain.service.OccupationService
+import com.yuiyeong.ticketing.domain.service.SeatService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZonedDateTime
+
+@Component
+class OccupySeatUseCaseImpl(
+    private val concertEventService: ConcertEventService,
+    private val occupationService: OccupationService,
+    private val seatService: SeatService,
+) : OccupySeatUseCase {
+    @Transactional
+    override fun execute(
+        userId: Long,
+        concertEventId: Long,
+        seatId: Long,
+    ): OccupationResult {
+        val now = ZonedDateTime.now().asUtc
+        val concertEvent = concertEventService.getConcertEvent(concertEventId)
+        concertEvent.verifyWithinReservationPeriod(now)
+
+        val seatIds = listOf(seatId)
+        seatService.occupy(seatIds)
+
+        val occupation = occupationService.createOccupation(userId, concertEventId, seatIds)
+        concertEventService.refreshAvailableSeats(concertEventId)
+        return OccupationResult.from(occupation)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ReserveSeatUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ReserveSeatUseCase.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.ReservationResult
+
+interface ReserveSeatUseCase {
+    fun execute(
+        userId: Long,
+        concertEventId: Long,
+        occupationId: Long,
+    ): ReservationResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ReserveSeatUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/reservation/ReserveSeatUseCaseImpl.kt
@@ -1,0 +1,29 @@
+package com.yuiyeong.ticketing.application.usecase.reservation
+
+import com.yuiyeong.ticketing.application.dto.ReservationResult
+import com.yuiyeong.ticketing.domain.service.ConcertEventService
+import com.yuiyeong.ticketing.domain.service.OccupationService
+import com.yuiyeong.ticketing.domain.service.ReservationService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ReserveSeatUseCaseImpl(
+    private val concertEventService: ConcertEventService,
+    private val reservationService: ReservationService,
+    private val occupationService: OccupationService,
+) : ReserveSeatUseCase {
+    @Transactional
+    override fun execute(
+        userId: Long,
+        concertEventId: Long,
+        occupationId: Long,
+    ): ReservationResult {
+        val reservation = reservationService.reserve(userId, concertEventId, occupationId)
+
+        occupationService.release(userId, occupationId)
+
+        val concertEvent = concertEventService.getConcertEvent(concertEventId)
+        return ReservationResult.from(concertEvent, reservation)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/token/ValidateTokenUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/token/ValidateTokenUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.token
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+interface ValidateTokenUseCase {
+    fun execute(token: String): QueueEntryResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/token/ValidateTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/token/ValidateTokenUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.application.usecase.token
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.domain.service.QueueService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ValidateTokenUseCaseImpl(
+    private val queueService: QueueService,
+) : ValidateTokenUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(token: String): QueueEntryResult {
+        val positionOffset = queueService.getFirstWaitingPosition()
+        return QueueEntryResult.from(queueService.getEntry(token), positionOffset)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/ChargeWalletUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/ChargeWalletUseCase.kt
@@ -1,0 +1,10 @@
+package com.yuiyeong.ticketing.application.usecase.wallet
+
+import com.yuiyeong.ticketing.application.dto.WalletResult
+
+interface ChargeWalletUseCase {
+    fun execute(
+        userId: Long,
+        amount: Long,
+    ): WalletResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/ChargeWalletUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/ChargeWalletUseCaseImpl.kt
@@ -1,0 +1,21 @@
+package com.yuiyeong.ticketing.application.usecase.wallet
+
+import com.yuiyeong.ticketing.application.dto.WalletResult
+import com.yuiyeong.ticketing.domain.service.WalletService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Component
+class ChargeWalletUseCaseImpl(
+    private val walletService: WalletService,
+) : ChargeWalletUseCase {
+    @Transactional
+    override fun execute(
+        userId: Long,
+        amount: Long,
+    ): WalletResult {
+        walletService.charge(userId, BigDecimal(amount))
+        return WalletResult.from(walletService.getUserWallet(userId))
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/GetBalanceUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/GetBalanceUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.wallet
+
+import com.yuiyeong.ticketing.application.dto.WalletResult
+
+interface GetBalanceUseCase {
+    fun execute(userId: Long): WalletResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/GetBalanceUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/wallet/GetBalanceUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.application.usecase.wallet
+
+import com.yuiyeong.ticketing.application.dto.WalletResult
+import com.yuiyeong.ticketing.domain.service.WalletService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class GetBalanceUseCaseImpl(
+    private val walletService: WalletService,
+) : GetBalanceUseCase {
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long): WalletResult {
+        val wallet = walletService.getUserWallet(userId)
+        return WalletResult.from(wallet)
+    }
+}


### PR DESCRIPTION
## UseCase

- Application 계층에 속한다는 것을 package 로 표현하였습니다.
- 비지니스 UseCase 마다 한 interface 로 만들었습니다.
- UseCase 의 반환 DTO 는 `Result` 라는 postfix 를 붙였습니다.
- UseCase 는 도메인 서비스를 참조하여 기능을 구현하도록 했습니다.
- 여기서 Transaction 을 관리할 수 있도록 `@Transactional` 을 사용했습니다.
- UseCase 를 연관성 있는 것끼리 패키징하였습니다.
    - concert
    - payment
    - queue
    - reservation
    - token
    - wallet 

### 리뷰포인트
- ReserveSeatUseCase 에 대해 리뷰 해주시면 감사하겠습니다.