### PR TITLE
Feat: Swagger 를 통핸 API 문서 구현

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/SwaggerConfig.kt
@@ -1,0 +1,35 @@
+package com.yuiyeong.ticketing.config.swagger
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securitySchemeName = "bearerAuth"
+        return OpenAPI()
+            .info(
+                Info()
+                    .title("콘서트 좌석 예약 서비스 API")
+                    .description("콘서트 좌석 예약 서비스의 API 문서입니다.")
+                    .version("1.0.0"),
+            ).addSecurityItem(SecurityRequirement().addList(securitySchemeName))
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        securitySchemeName,
+                        SecurityScheme()
+                            .name(securitySchemeName)
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT"),
+                    ),
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/AvailableConcertEventsApiDoc.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/AvailableConcertEventsApiDoc.kt
@@ -1,0 +1,59 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.api
+
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InternalServerErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InvalidTokenErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NoAuthErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NotFoundConcertErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.UserTokenHeader
+import com.yuiyeong.ticketing.config.swagger.schema.response.AvailableConcertEventsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "예약 가능한 콘서트 이벤트 조회", description = "특정 콘서트의 예약 가능한 날짜 목록을 조회합니다.")
+@UserTokenHeader
+@Parameter(
+    name = "concertId",
+    description = "조회할 콘서트의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AvailableConcertEventsResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "list": [
+                            {
+                                "id": 1,
+                                "date": "2023-07-01"
+                            },
+                            {
+                                "id": 2,
+                                "date": "2023-07-02"
+                            }
+                        ]
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+@InvalidTokenErrorResponse
+@NotFoundConcertErrorResponse
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class AvailableConcertEventsApiDoc

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/ConcertEventApiDoc.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/ConcertEventApiDoc.kt
@@ -1,0 +1,125 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.api
+
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InsufficientBalanceErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InternalServerErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InvalidSeatErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InvalidTokenErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NoAuthErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NotFoundConcertEventErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NotFoundSeatErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.OccupationExpiredErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.UserTokenHeader
+import com.yuiyeong.ticketing.config.swagger.schema.request.OccupySeatRequest
+import com.yuiyeong.ticketing.config.swagger.schema.request.ReserveSeatRequest
+import com.yuiyeong.ticketing.config.swagger.schema.response.AvailableSeatsResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.OccupySeatResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.ReserveSeatResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "예약 가능한 좌석 조회", description = "특정 콘서트 이벤트의 예약 가능한 좌석 목록을 조회합니다.")
+@UserTokenHeader
+@Parameter(
+    name = "concertEventId",
+    description = "조회할 콘서트 이벤트의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AvailableSeatsResponse::class),
+        ),
+    ],
+)
+@InvalidTokenErrorResponse
+@NotFoundConcertEventErrorResponse
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class AvailableSeatsApiDoc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "좌석 점유", description = "특정 콘서트 이벤트의 좌석을 점유합니다.")
+@UserTokenHeader
+@Parameter(
+    name = "concertEventId",
+    description = "좌석을 점유할 콘서트 이벤트의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@RequestBody(
+    required = true,
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = OccupySeatRequest::class),
+        ),
+    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = OccupySeatResponse::class),
+        ),
+    ],
+)
+@InvalidTokenErrorResponse
+@NotFoundConcertEventErrorResponse
+@InvalidSeatErrorResponse
+@NotFoundSeatErrorResponse
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class OccupySeatApiDoc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "좌석 예약", description = "점유한 좌석에 대해 결제 및 예약을 진행합니다.")
+@UserTokenHeader
+@Parameter(
+    name = "concertEventId",
+    description = "좌석을 예약할 콘서트 이벤트의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@RequestBody(
+    required = true,
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ReserveSeatRequest::class),
+        ),
+    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ReserveSeatResponse::class),
+        ),
+    ],
+)
+@InvalidTokenErrorResponse
+@NotFoundConcertEventErrorResponse
+@InvalidSeatErrorResponse
+@NotFoundSeatErrorResponse
+@InsufficientBalanceErrorResponse
+@OccupationExpiredErrorResponse
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class ReserveSeatApiDoc

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/PaymentsApiDoc.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/PaymentsApiDoc.kt
@@ -1,0 +1,63 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.api
+
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InternalServerErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NoAuthErrorResponse
+import com.yuiyeong.ticketing.config.swagger.schema.request.PayRequest
+import com.yuiyeong.ticketing.config.swagger.schema.response.PaymentHistoryResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.PaymentResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "결제", description = "사용자가 한 예약에 대한 결제를 합니다.")
+@RequestBody(
+    required = true,
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PayRequest::class),
+        ),
+    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PaymentResponse::class),
+        ),
+    ],
+)
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class PayApiDoc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "결제 내역 목록 조회", description = "사용자의 결제 내역 목록을 조회합니다.")
+@Parameter(
+    name = "userId",
+    description = "조회할 사용자의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = PaymentHistoryResponse::class),
+        ),
+    ],
+)
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class PaymentHistoryApiDoc

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/QueueApiDoc.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/QueueApiDoc.kt
@@ -1,0 +1,84 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.api
+
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InternalServerErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InvalidTokenErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NoAuthErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.UserTokenHeader
+import com.yuiyeong.ticketing.config.swagger.schema.request.QueueTokenIssuanceRequest
+import com.yuiyeong.ticketing.config.swagger.schema.response.ErrorResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.QueueStatusResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.QueueTokenIssuanceResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "대기열 Token 발급", description = "사용자를 대기열에 넣고, 그 대기 정보에 대한 token 을 내려줍니다.")
+@RequestBody(
+    description = "토큰 발급 요청",
+    required = true,
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = QueueTokenIssuanceRequest::class),
+        ),
+    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = QueueTokenIssuanceResponse::class),
+        ),
+    ],
+)
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class QueueTokenIssuanceApiDoc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "대기열 정보 조회", description = "발급받은 Token으로 대기 정보를 조회합니다.")
+@UserTokenHeader
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = QueueStatusResponse::class),
+        ),
+    ],
+)
+@InvalidTokenErrorResponse
+@ApiResponse(
+    responseCode = "404",
+    description = "대기열에 없는 토큰",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "not_found_in_queue",
+                            "message": "해당 토큰으로 대기 중인 정보를 찾을 수 없습니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class QueueStatusApiDoc

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/WalletApiDoc.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/api/WalletApiDoc.kt
@@ -1,0 +1,71 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.api
+
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InternalServerErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.InvalidAmountErrorResponse
+import com.yuiyeong.ticketing.config.swagger.annotation.common.NoAuthErrorResponse
+import com.yuiyeong.ticketing.config.swagger.schema.request.ChargeWalletRequest
+import com.yuiyeong.ticketing.config.swagger.schema.response.ChargeWalletResponse
+import com.yuiyeong.ticketing.config.swagger.schema.response.WalletBalanceResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "잔액 조회", description = "사용자의 현재 잔액 정보를 조회합니다.")
+@Parameter(
+    name = "userId",
+    description = "조회할 사용자의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = WalletBalanceResponse::class),
+        ),
+    ],
+)
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class WalletBalanceApiDoc
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Operation(summary = "잔액 충전", description = "사용자의 잔액을 충전합니다.")
+@Parameter(
+    name = "userId",
+    description = "충전할 사용자의 ID",
+    required = true,
+    `in` = ParameterIn.PATH,
+)
+@RequestBody(
+    required = true,
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ChargeWalletRequest::class),
+        ),
+    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "성공",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ChargeWalletResponse::class),
+        ),
+    ],
+)
+@InvalidAmountErrorResponse
+@NoAuthErrorResponse
+@InternalServerErrorResponse
+annotation class ChargeWalletApiDoc

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/common/ErrorResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/common/ErrorResponse.kt
@@ -1,0 +1,240 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.common
+
+import com.yuiyeong.ticketing.config.swagger.schema.response.ErrorResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "500",
+    description = "서버 오류 발생",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+        ),
+    ],
+)
+annotation class InternalServerErrorResponse
+
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "401",
+    description = "인증 오류 발생",
+    content = [
+        Content(mediaType = "application/json"),
+    ],
+)
+annotation class NoAuthErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "유효하지 않은 토큰",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "invalid_token",
+                            "message": "유효하지 않은 token 입니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class InvalidTokenErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "콘서트를 찾을 수 없음",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "not_found_concert",
+                            "message": "요청한 콘서트를 찾을 수 없습니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class NotFoundConcertErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "콘서트 이벤트를 찾을 수 없음",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "not_found_concert_event",
+                            "message": "요청한 콘서트 이벤트를 찾을 수 없습니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class NotFoundConcertEventErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "유효하지 않은 좌석",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "invalid_seat",
+                            "message": "이미 점유되었거나 예약된 좌석입니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class InvalidSeatErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "좌석을 찾을 수 없음",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "not_found_seat",
+                            "message": "콘서트 이벤트에서 해당 좌석을 찾을 수 없습니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class NotFoundSeatErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "잔액 부족",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "insufficient_balance",
+                            "message": "잔액이 부족합니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class InsufficientBalanceErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "점유 시간 만료",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "occupation_expired",
+                            "message": "좌석 점유 시간이 만료되었습니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class OccupationExpiredErrorResponse
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "유효하지 않은 충전 금액",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                    {
+                        "error": {
+                            "code": "invalid_amount",
+                            "message": "유효하지 않은 충전 금액입니다."
+                        }
+                    }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class InvalidAmountErrorResponse

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/common/UserTokenHeader.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/annotation/common/UserTokenHeader.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.config.swagger.annotation.common
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Parameter(
+    name = "User-Token",
+    description = "대기열 진입 시 발급받은 토큰",
+    required = true,
+    `in` = ParameterIn.HEADER,
+)
+annotation class UserTokenHeader

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/ChargeWalletRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/ChargeWalletRequest.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "잔액 충전 요청")
+data class ChargeWalletRequest(
+    @field:Schema(description = "충전할 금액", example = "50000")
+    val amount: Int,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/OccupySeatRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/OccupySeatRequest.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "좌석 점유 요청")
+data class OccupySeatRequest(
+    @field:Schema(description = "점유할 좌석 ID", example = "1")
+    val seatId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/PayRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/PayRequest.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "결제 요청")
+data class PayRequest(
+    @field:Schema(description = "결제할 reservation 의 id", example = "21")
+    val reservationId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/QueueTokenIssuanceRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/QueueTokenIssuanceRequest.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "userId 를 가지는 객체")
+data class QueueTokenIssuanceRequest(
+    @field:Schema(description = "사용자의 id", example = "11")
+    val userId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/ReserveSeatRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/request/ReserveSeatRequest.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "좌석 예약 요청")
+data class ReserveSeatRequest(
+    @field:Schema(description = "예약할 좌석 ID", example = "1234")
+    val seatId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/AvailableConcertEventsResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/AvailableConcertEventsResponse.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "예약 가능한 콘서트 이벤트 정보")
+data class AvailableConcertEventData(
+    @field:Schema(description = "콘서트 이벤트의 id", example = "1")
+    val id: Long,
+    @field:Schema(description = "예약 가능한 날짜", example = "2023-07-01")
+    val date: String,
+)
+
+@Schema(description = "예약 가능한 콘서트 이벤트 목록 응답")
+data class AvailableConcertEventsResponse(
+    @Schema(description = "예약 가능한 콘서트 이벤트 목록")
+    val list: List<AvailableConcertEventData>,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/AvailableSeatsResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/AvailableSeatsResponse.kt
@@ -1,0 +1,19 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "예약 가능한 좌석 정보")
+data class AvailableSeatData(
+    @field:Schema(description = "좌석 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "좌석 번호", example = "12")
+    val seatNumber: String,
+    @field:Schema(description = "좌석 가격", example = "50000")
+    val price: Int,
+)
+
+@Schema(description = "예약 가능한 좌석 목록 응답")
+data class AvailableSeatsResponse(
+    @Schema(description = "예약 가능한 좌석 목록")
+    val list: List<AvailableSeatData>,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ChargeWalletResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ChargeWalletResponse.kt
@@ -1,0 +1,15 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "충전 후 잔액 정보")
+data class ChargeWalletData(
+    @field:Schema(description = "갱신된 잔액", example = "150000")
+    val balance: Int,
+)
+
+@Schema(description = "잔액 충전 응답")
+data class ChargeWalletResponse(
+    @Schema(description = "충전 후 잔액 정보")
+    val data: ChargeWalletData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ErrorResponse.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "에러 객체")
+data class ErrorData(
+    @field:Schema(description = "에러 코드", example = "internal_server_error")
+    val code: String,
+    @field:Schema(description = "에러 메시지", example = "서버 내부 오류가 발생했습니다.")
+    val message: String,
+)
+
+@Schema(description = "에러 응답 형식")
+data class ErrorResponse(
+    @Schema(contentSchema = ErrorData::class)
+    val error: ErrorData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/OccupySeatResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/OccupySeatResponse.kt
@@ -1,0 +1,21 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "점유된 좌석 정보")
+data class OccupiedSeatData(
+    @field:Schema(description = "점유한 좌석의 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "점유한 좌석의 좌석 번호", example = "50")
+    val seatNumber: String,
+    @field:Schema(description = "점유한 좌석의 가격", example = "50000")
+    val price: Int,
+    @field:Schema(description = "점유 만료 시간", example = "2023-07-01T12:05:00Z")
+    val expirationTime: String,
+)
+
+@Schema(description = "좌석 점유 응답")
+data class OccupySeatResponse(
+    @Schema(description = "점유된 좌석 정보")
+    val data: OccupiedSeatData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/PaymentHistoryResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/PaymentHistoryResponse.kt
@@ -1,0 +1,23 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "결제 내역 정보")
+data class PaymentData(
+    @field:Schema(description = "결제 ID", example = "12")
+    val id: Long,
+    @field:Schema(description = "예약 ID", example = "5679")
+    val reservationId: Long,
+    @field:Schema(description = "결제 금액", example = "60000")
+    val amount: Int,
+    @field:Schema(description = "결제 상태", example = "success")
+    val status: String,
+    @field:Schema(description = "결제 시간", example = "2023-07-02T14:30:00Z")
+    val paidAt: String,
+)
+
+@Schema(description = "결제 내역 목록 응답")
+data class PaymentHistoryResponse(
+    @Schema(description = "결제 내역 목록")
+    val list: List<PaymentData>,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/PaymentResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/PaymentResponse.kt
@@ -1,0 +1,9 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "결제 결과 응답")
+data class PaymentResponse(
+    @Schema(description = "결제 내역")
+    val data: PaymentData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/QueueStatusResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/QueueStatusResponse.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "대기열 상태 정보 객체")
+data class QueueStatusData(
+    @field:Schema(description = "대기열에서의 현재 위치", example = "15")
+    val queuePosition: Int,
+    @field:Schema(description = "예상 대기 시간(분)", example = "10")
+    val estimatedWaitingTime: Int,
+)
+
+@Schema(description = "대기열 상태 조회 응답")
+data class QueueStatusResponse(
+    @Schema(contentSchema = QueueStatusData::class)
+    val data: QueueStatusData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/QueueTokenIssuanceResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/QueueTokenIssuanceResponse.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "발급된 Token 객체")
+data class TokenData(
+    @field:Schema(description = "대기 정보에 대한 token", example = "a21kTkseTestToken")
+    val token: String,
+    @field:Schema(description = "예상 대기 시간(분)", example = "20")
+    val estimatedWaitingTime: String,
+)
+
+@Schema(description = "대기열 token 발급 응답")
+data class QueueTokenIssuanceResponse(
+    @Schema(contentSchema = TokenData::class)
+    val data: TokenData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ReserveSeatResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/ReserveSeatResponse.kt
@@ -1,0 +1,23 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "예약된 좌석 정보")
+data class ReservedSeatData(
+    @field:Schema(description = "예약 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "콘서트 이벤트 ID", example = "1")
+    val concertEventId: Long,
+    @field:Schema(description = "총 예약한 좌석 수", example = "1")
+    val totalSeats: Int,
+    @field:Schema(description = "총 결제 금액", example = "50000")
+    val totalAmount: Int,
+    @field:Schema(description = "예약된 시간", example = "2023-07-01T12:05:00Z")
+    val createdAt: String,
+)
+
+@Schema(description = "좌석 예약 응답")
+data class ReserveSeatResponse(
+    @Schema(description = "예약된 좌석 정보")
+    val data: ReservedSeatData,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/WalletBalanceResponse.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/swagger/schema/response/WalletBalanceResponse.kt
@@ -1,0 +1,15 @@
+package com.yuiyeong.ticketing.config.swagger.schema.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "잔액 정보")
+data class WalletBalanceData(
+    @field:Schema(description = "현재 잔액", example = "100000")
+    val balance: Int,
+)
+
+@Schema(description = "잔액 조회 응답")
+data class WalletBalanceResponse(
+    @Schema(description = "잔액 정보")
+    val data: WalletBalanceData,
+)


### PR DESCRIPTION
## Swagger 용 Annotation

- config 에 swagger 패키지를 만들어 swagger 관련 코드를 모두 작성
    - Swagger 에서 사용하는 Schema 도 모두 여기에 추가
    - `@UserTokenHeader` annotation 을 만들어서, `User-Token` 이 필수인 api 추가할 수 있도록 함
- API 마다 annotaion 을 만들어, controller 에서는 해당 annotation 만 붙이면 swagger 문서가 생성되도록 했습니다.

### 리뷰 포인트
- 현업에서는 Swagger 문서 관리는 어떻게 하는지 궁금합니다.
- Controller 나 Controller 의 Dto 에 Swagger 관련 코드가 작성되어있는 것은 주객이 전도되었다고 생각되어 따로 관리를 하도록 만들었으나, API 의 추가나 변화가 있을 때 Swagger 용 annotation 도 수정을 해야하는 문제가 있다고 생각이 들이 이 방법이 좋은 방법인지 고민이 됩니다.

