### PR TITLE
Feat: User-Token 을 처리할 Interceptor 및 Resolver 추가

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/CurrentEntry.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/CurrentEntry.kt
@@ -1,0 +1,8 @@
+package com.yuiyeong.ticketing.application.annotation
+
+/**
+ * Http header 에 User-Token 로 부터 QueueEntry 를 추출함을 나타내는 annotation
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentEntry

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/RequiresUserToken.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/annotation/RequiresUserToken.kt
@@ -1,0 +1,12 @@
+package com.yuiyeong.ticketing.application.annotation
+
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+
+/**
+ * Http header 에 User-Token 이 필수임을 나타내는 annotation
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RequiresUserToken(
+    val allowedStatus: Array<QueueEntryStatus> = [QueueEntryStatus.PROCESSING],
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
@@ -1,0 +1,19 @@
+package com.yuiyeong.ticketing.config
+
+import com.yuiyeong.ticketing.application.usecase.token.ValidateTokenUseCase
+import com.yuiyeong.ticketing.presentation.interceptor.UserTokenInterceptor
+import com.yuiyeong.ticketing.presentation.resolver.EntryArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val validateTokenUseCase: ValidateTokenUseCase,
+    private val entryArgumentResolver: EntryArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(UserTokenInterceptor(validateTokenUseCase))
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/WebMvcConfig.kt
@@ -16,4 +16,8 @@ class WebMvcConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(UserTokenInterceptor(validateTokenUseCase))
     }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(entryArgumentResolver)
+    }
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/interceptor/UserTokenInterceptor.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/interceptor/UserTokenInterceptor.kt
@@ -1,0 +1,42 @@
+package com.yuiyeong.ticketing.presentation.interceptor
+
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.usecase.token.ValidateTokenUseCase
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.domain.exception.TokenNotProcessableException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class UserTokenInterceptor(
+    private val validateTokenUseCase: ValidateTokenUseCase,
+) : HandlerInterceptor {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        if (handler is HandlerMethod) {
+            val requiresUserToken = handler.getMethodAnnotation(RequiresUserToken::class.java) ?: return true
+
+            val token = request.getHeader(HEADER_USER_TOKEN) ?: throw InvalidTokenException()
+            val entryResult = validateTokenUseCase.execute(token)
+
+            return if (requiresUserToken.allowedStatus.isEmpty() || entryResult.status in requiresUserToken.allowedStatus) {
+                request.setAttribute(ATTR_QUEUE_ENTRY, entryResult)
+                true
+            } else {
+                throw TokenNotProcessableException()
+            }
+        }
+        return true
+    }
+
+    companion object {
+        const val ATTR_QUEUE_ENTRY = "queue_entry"
+        private const val HEADER_USER_TOKEN = "User-Token"
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/resolver/EntryArgumentResolver.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/resolver/EntryArgumentResolver.kt
@@ -1,0 +1,30 @@
+package com.yuiyeong.ticketing.presentation.resolver
+
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.domain.exception.InvalidTokenException
+import com.yuiyeong.ticketing.presentation.interceptor.UserTokenInterceptor
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class EntryArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(CurrentEntry::class.java) && parameter.parameterType == QueueEntryResult::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Any {
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java)
+        return request?.getAttribute(UserTokenInterceptor.ATTR_QUEUE_ENTRY) as? QueueEntryResult
+            ?: throw InvalidTokenException()
+    }
+}


### PR DESCRIPTION
## UserTokenInterceptor

- @RequiresUserToken 가 있을 때만 request 에 대해서 검증을 하도록했습니다.
- Header 에 있는 User-Token 에 대해서 유효성 검사를 합니다.
- 유효한 QueueEntory 의 status 가 허용된 status 에 포함되는지검사합니다.
- 마지막으로 attribute 에 유효한 QueueEntry 를 넣어줍니다.

## EntryArgumentResolver

- @CurrentEntry 가 붙은 parameter 가 QueueEntry 면, request 의 Attribute 에서 추출하여 반환합니다.

## ReviewPoint
### UserTokenInterceptor
- 유효성 검사는 UseCase 를 이용해서 하고 있는데, status 에 대한 처리는 interceptor 안에서 하고 있는데 이부분 확인부탁드립니다.
- 유효성을 검사한 후 token 으로 부터 QueueEntry 를 DB 에서 가져오고 있습니다. 이게 성능상에 문제가 될 수 있는지 확인 부탁드립니다.