### PR TITLE
Feat: Controller 구현

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertController.kt
@@ -1,0 +1,29 @@
+package com.yuiyeong.ticketing.presentation.controller
+
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.usecase.concert.GetAvailableConcertEventsUseCase
+import com.yuiyeong.ticketing.config.swagger.annotation.api.AvailableConcertEventsApiDoc
+import com.yuiyeong.ticketing.presentation.dto.ConcertEventResponseDto
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingListResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/concerts")
+@Tag(name = "콘서트", description = "콘서트 관련 api")
+class ConcertController(
+    private val getAvailableConcertEventsUseCase: GetAvailableConcertEventsUseCase,
+) {
+    @GetMapping("{concertId}/available-events")
+    @RequiresUserToken
+    @AvailableConcertEventsApiDoc
+    fun getAvailableEvents(
+        @PathVariable("concertId") concertId: Long,
+    ): TicketingListResponse<ConcertEventResponseDto> {
+        val list = getAvailableConcertEventsUseCase.execute(concertId).map { ConcertEventResponseDto.from(it) }
+        return TicketingListResponse(list)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertEventController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/ConcertEventController.kt
@@ -1,0 +1,68 @@
+package com.yuiyeong.ticketing.presentation.controller
+
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.application.usecase.concert.GetAvailableSeatsUseCase
+import com.yuiyeong.ticketing.application.usecase.reservation.OccupySeatUseCase
+import com.yuiyeong.ticketing.application.usecase.reservation.ReserveSeatUseCase
+import com.yuiyeong.ticketing.config.swagger.annotation.api.AvailableSeatsApiDoc
+import com.yuiyeong.ticketing.config.swagger.annotation.api.OccupySeatApiDoc
+import com.yuiyeong.ticketing.config.swagger.annotation.api.ReserveSeatApiDoc
+import com.yuiyeong.ticketing.presentation.dto.OccupationResponseDto
+import com.yuiyeong.ticketing.presentation.dto.ReservationResponseDto
+import com.yuiyeong.ticketing.presentation.dto.SeatResponseDto
+import com.yuiyeong.ticketing.presentation.dto.request.ConcertEventOccupationRequest
+import com.yuiyeong.ticketing.presentation.dto.request.ConcertEventReservationRequest
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingListResponse
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/concert-events")
+@Tag(name = "콘서트 이벤트", description = "콘서트 이벤트 관련 api")
+class ConcertEventController(
+    private val getAvailableSeatsUseCase: GetAvailableSeatsUseCase,
+    private val occupySeatUseCase: OccupySeatUseCase,
+    private val reserveSeatUseCase: ReserveSeatUseCase,
+) {
+    @GetMapping("{concertEventId}/available-seats")
+    @RequiresUserToken
+    @AvailableSeatsApiDoc
+    fun getAvailableSeats(
+        @PathVariable("concertEventId") concertEventId: Long,
+    ): TicketingListResponse<SeatResponseDto> {
+        val list = getAvailableSeatsUseCase.execute(concertEventId).map { SeatResponseDto.from(it) }
+        return TicketingListResponse(list)
+    }
+
+    @PostMapping("{concertEventId}/occupy")
+    @RequiresUserToken
+    @OccupySeatApiDoc
+    fun occupy(
+        @CurrentEntry entry: QueueEntryResult,
+        @PathVariable("concertEventId") concertEventId: Long,
+        @RequestBody req: ConcertEventOccupationRequest,
+    ): TicketingResponse<OccupationResponseDto> {
+        val data = OccupationResponseDto.from(occupySeatUseCase.execute(entry.userId, concertEventId, req.seatId))
+        return TicketingResponse(data)
+    }
+
+    @PostMapping("{concertEventId}/reserve")
+    @RequiresUserToken
+    @ReserveSeatApiDoc
+    fun reserve(
+        @CurrentEntry entry: QueueEntryResult,
+        @PathVariable("concertEventId") concertEventId: Long,
+        @RequestBody req: ConcertEventReservationRequest,
+    ): TicketingResponse<ReservationResponseDto> {
+        val data = ReservationResponseDto.from(reserveSeatUseCase.execute(entry.userId, concertEventId, req.seatId))
+        return TicketingResponse(data)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/PaymentController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/PaymentController.kt
@@ -1,0 +1,48 @@
+package com.yuiyeong.ticketing.presentation.controller
+
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.application.usecase.payment.GetPaymentListUseCase
+import com.yuiyeong.ticketing.application.usecase.payment.PayUseCase
+import com.yuiyeong.ticketing.config.swagger.annotation.api.PayApiDoc
+import com.yuiyeong.ticketing.config.swagger.annotation.api.PaymentHistoryApiDoc
+import com.yuiyeong.ticketing.presentation.dto.PaymentResponseDto
+import com.yuiyeong.ticketing.presentation.dto.request.PayRequest
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingListResponse
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "결제", description = "결제 관련 api")
+class PaymentController(
+    private val payUseCase: PayUseCase,
+    private val getPaymentListUseCase: GetPaymentListUseCase,
+) {
+    @PostMapping("payments")
+    @RequiresUserToken
+    @PayApiDoc
+    fun pay(
+        @CurrentEntry entry: QueueEntryResult,
+        @RequestBody req: PayRequest,
+    ): TicketingResponse<PaymentResponseDto> {
+        val data = PaymentResponseDto.from(payUseCase.execute(entry.userId, entry.id, req.reservationId))
+        return TicketingResponse(data)
+    }
+
+    @GetMapping("users/{userId}/payments")
+    @PaymentHistoryApiDoc
+    fun getPayments(
+        @PathVariable("userId") userId: Long,
+    ): TicketingListResponse<PaymentResponseDto> {
+        val list = getPaymentListUseCase.execute(userId).map { PaymentResponseDto.from(it) }
+        return TicketingListResponse(list)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/QueueController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/QueueController.kt
@@ -1,0 +1,52 @@
+package com.yuiyeong.ticketing.presentation.controller
+
+import com.yuiyeong.ticketing.application.annotation.CurrentEntry
+import com.yuiyeong.ticketing.application.annotation.RequiresUserToken
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+import com.yuiyeong.ticketing.application.usecase.queue.EnterQueueUseCase
+import com.yuiyeong.ticketing.config.swagger.annotation.api.QueueStatusApiDoc
+import com.yuiyeong.ticketing.config.swagger.annotation.api.QueueTokenIssuanceApiDoc
+import com.yuiyeong.ticketing.domain.model.QueueEntryStatus
+import com.yuiyeong.ticketing.presentation.dto.QueuePositionResponseDto
+import com.yuiyeong.ticketing.presentation.dto.QueueTokenResponseDto
+import com.yuiyeong.ticketing.presentation.dto.request.GeneratingQueueTokenRequest
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/queue")
+@Tag(name = "대기열", description = "대기열 관련 API")
+class QueueController(
+    private val enterQueueUseCase: EnterQueueUseCase,
+) {
+    @PostMapping("token")
+    @QueueTokenIssuanceApiDoc
+    fun generateToken(
+        @RequestBody req: GeneratingQueueTokenRequest,
+    ): TicketingResponse<QueueTokenResponseDto> {
+        val data = QueueTokenResponseDto.from(enterQueueUseCase.execute(req.userId))
+        return TicketingResponse(data)
+    }
+
+    @GetMapping("status")
+    @RequiresUserToken(
+        allowedStatus = [
+            QueueEntryStatus.WAITING,
+            QueueEntryStatus.PROCESSING,
+            QueueEntryStatus.EXITED,
+            QueueEntryStatus.EXPIRED,
+        ],
+    )
+    @QueueStatusApiDoc
+    fun getStatus(
+        @CurrentEntry entry: QueueEntryResult,
+    ): TicketingResponse<QueuePositionResponseDto> {
+        val data = QueuePositionResponseDto.from(entry)
+        return TicketingResponse(data)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/WalletController.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/controller/WalletController.kt
@@ -1,0 +1,47 @@
+package com.yuiyeong.ticketing.presentation.controller
+
+import com.yuiyeong.ticketing.application.usecase.wallet.ChargeWalletUseCase
+import com.yuiyeong.ticketing.application.usecase.wallet.GetBalanceUseCase
+import com.yuiyeong.ticketing.config.swagger.annotation.api.ChargeWalletApiDoc
+import com.yuiyeong.ticketing.config.swagger.annotation.api.WalletBalanceApiDoc
+import com.yuiyeong.ticketing.presentation.dto.WalletResponseDto
+import com.yuiyeong.ticketing.presentation.dto.request.ChargingWalletRequest
+import com.yuiyeong.ticketing.presentation.dto.response.TicketingResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users")
+@Tag(name = "지갑", description = "지갑 관련 api")
+class WalletController {
+    @Autowired
+    private lateinit var chargeWalletUseCase: ChargeWalletUseCase
+
+    @Autowired
+    private lateinit var getBalanceUseCase: GetBalanceUseCase
+
+    @GetMapping("{userId}/wallet")
+    @WalletBalanceApiDoc
+    fun getBalance(
+        @PathVariable("userId") userId: Long,
+    ): TicketingResponse<WalletResponseDto> {
+        val data = WalletResponseDto.from(getBalanceUseCase.execute(userId))
+        return TicketingResponse(data)
+    }
+
+    @PatchMapping("{userId}/wallet/charge")
+    @ChargeWalletApiDoc
+    fun charge(
+        @PathVariable("userId") userId: Long,
+        @RequestBody req: ChargingWalletRequest,
+    ): TicketingResponse<WalletResponseDto> {
+        val data = WalletResponseDto.from(chargeWalletUseCase.execute(userId, req.amount))
+        return TicketingResponse(data)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/ConcertEventResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/ConcertEventResponseDto.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.ConcertEventResult
+import java.time.ZonedDateTime
+
+data class ConcertEventResponseDto(
+    val id: Long,
+    val date: ZonedDateTime,
+) {
+    companion object {
+        fun from(concertEventResult: ConcertEventResult): ConcertEventResponseDto =
+            ConcertEventResponseDto(concertEventResult.id, concertEventResult.performanceSchedule.start)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/OccupationResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/OccupationResponseDto.kt
@@ -1,0 +1,17 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.OccupationResult
+import java.time.ZonedDateTime
+
+data class OccupationResponseDto(
+    val id: Long,
+    val expiresAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(occupationResult: OccupationResult): OccupationResponseDto =
+            OccupationResponseDto(
+                occupationResult.id,
+                occupationResult.expiresAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/PaymentResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/PaymentResponseDto.kt
@@ -1,0 +1,24 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.PaymentResult
+import java.math.BigDecimal
+import java.time.ZonedDateTime
+
+data class PaymentResponseDto(
+    val id: Long,
+    val reservationId: Long,
+    val amount: BigDecimal,
+    val status: String,
+    val paidAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(paymentResult: PaymentResult): PaymentResponseDto =
+            PaymentResponseDto(
+                paymentResult.id,
+                paymentResult.reservationId,
+                paymentResult.amount,
+                paymentResult.status.toString(),
+                paymentResult.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/QueuePositionResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/QueuePositionResponseDto.kt
@@ -1,0 +1,13 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+data class QueuePositionResponseDto(
+    val queuePosition: Long,
+    val estimatedWaitingTime: Long,
+) {
+    companion object {
+        fun from(entryDto: QueueEntryResult): QueuePositionResponseDto =
+            QueuePositionResponseDto(entryDto.position, entryDto.estimatedWaitingTime)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/QueueTokenResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/QueueTokenResponseDto.kt
@@ -1,0 +1,13 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.QueueEntryResult
+
+data class QueueTokenResponseDto(
+    val token: String,
+    val estimatedWaitingTime: Long,
+) {
+    companion object {
+        fun from(entityDto: QueueEntryResult): QueueTokenResponseDto =
+            QueueTokenResponseDto(entityDto.token, entityDto.estimatedWaitingTime)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/ReservationResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/ReservationResponseDto.kt
@@ -1,0 +1,27 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.ReservationResult
+import com.yuiyeong.ticketing.domain.model.ReservationStatus
+import java.math.BigDecimal
+import java.time.ZonedDateTime
+
+data class ReservationResponseDto(
+    val id: Long,
+    val concertPerformanceStartAt: ZonedDateTime,
+    val status: ReservationStatus,
+    val totalSeats: Int,
+    val totalAmount: BigDecimal,
+    val createdAt: ZonedDateTime,
+) {
+    companion object {
+        fun from(reservationResult: ReservationResult): ReservationResponseDto =
+            ReservationResponseDto(
+                reservationResult.id,
+                reservationResult.concertPerformanceStartAt,
+                reservationResult.status,
+                reservationResult.totalSeats,
+                reservationResult.totalAmount,
+                reservationResult.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/SeatResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/SeatResponseDto.kt
@@ -1,0 +1,19 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.SeatResult
+import java.math.BigDecimal
+
+data class SeatResponseDto(
+    val id: Long,
+    val seatNumber: String,
+    val price: BigDecimal,
+) {
+    companion object {
+        fun from(concertEventSeat: SeatResult): SeatResponseDto =
+            SeatResponseDto(
+                concertEventSeat.id,
+                concertEventSeat.seatNumber,
+                concertEventSeat.price,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/WalletResponseDto.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/WalletResponseDto.kt
@@ -1,0 +1,12 @@
+package com.yuiyeong.ticketing.presentation.dto
+
+import com.yuiyeong.ticketing.application.dto.WalletResult
+import java.math.BigDecimal
+
+data class WalletResponseDto(
+    val balance: BigDecimal,
+) {
+    companion object {
+        fun from(walletResult: WalletResult): WalletResponseDto = WalletResponseDto(walletResult.balance)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ChargingWalletRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ChargingWalletRequest.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.presentation.dto.request
+
+data class ChargingWalletRequest(
+    val amount: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ConcertEventOccupationRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ConcertEventOccupationRequest.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.presentation.dto.request
+
+data class ConcertEventOccupationRequest(
+    val seatId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ConcertEventReservationRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/ConcertEventReservationRequest.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.presentation.dto.request
+
+data class ConcertEventReservationRequest(
+    val seatId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/GeneratingQueueTokenRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/GeneratingQueueTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.presentation.dto.request
+
+data class GeneratingQueueTokenRequest(
+    val userId: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/PayRequest.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/dto/request/PayRequest.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.presentation.dto.request
+
+data class PayRequest(
+    val reservationId: Long,
+)


### PR DESCRIPTION
## Controller 구현

- Controller 는 들어온 요청을 UseCase 를 이용해서 처리하도록 하였습니다.
- 각 API 마다 request, response 에 대한 DTO 를 작성했습니다.

- 다음의 커스텀 annotation 을 사용하여, controller 의 코드를 정리하였습니다.
    - Swagger 로 작성한 API 문서를 나타내는 annotation
    - User-Token 을 처리하는 @RequiresUserToken
    - User-Token 에 대응하는 QueueEntry 를 받을 수 있도록하는 @CurrentEntry

- 아래의 Controller 를 구현했습니다.
    - ConcertController
    - ConcertEventController
    - PaymentController
    - QueueController
    - WalletController