### PR TITLE
Feat: Logging 구현

### DIFF
--- a/src/main/kotlin/com/yuiyeong/ticketing/config/FilterConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/FilterConfig.kt
@@ -1,0 +1,22 @@
+package com.yuiyeong.ticketing.config
+
+import com.yuiyeong.ticketing.presentation.filter.TicketingLoggingFilter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FilterConfig(
+    private val loggingProperties: LoggingProperties,
+) {
+    @Bean
+    @ConditionalOnBean(TicketingLoggingFilter::class)
+    fun loggingFilter(ticketingLoggingFilter: TicketingLoggingFilter): FilterRegistrationBean<TicketingLoggingFilter> {
+        val registrationBean = FilterRegistrationBean<TicketingLoggingFilter>()
+        registrationBean.filter = ticketingLoggingFilter
+        registrationBean.addUrlPatterns("/*")
+        registrationBean.order = 1
+        return registrationBean
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/LoggingProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/LoggingProperties.kt
@@ -1,0 +1,12 @@
+package com.yuiyeong.ticketing.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "logging.request-response")
+class LoggingProperties {
+    var enabled: Boolean = false
+    var previewLength: Int = 200
+    var maxContentLength: Int = 524288 // 500 KB
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/presentation/filter/TicketingLoggingFilter.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/presentation/filter/TicketingLoggingFilter.kt
@@ -1,0 +1,121 @@
+package com.yuiyeong.ticketing.presentation.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yuiyeong.ticketing.config.LoggingProperties
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.util.Locale
+
+@Component
+@ConditionalOnProperty(name = ["logging.request-response.enabled"], havingValue = "true")
+class TicketingLoggingFilter(
+    private val loggingProperties: LoggingProperties,
+) : OncePerRequestFilter() {
+    private val filterLogger = LoggerFactory.getLogger(TicketingLoggingFilter::class.java)
+    private val objectMapper = ObjectMapper()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestWrapper = ContentCachingRequestWrapper(request)
+        val responseWrapper = ContentCachingResponseWrapper(response)
+
+        val startTime = System.currentTimeMillis()
+
+        // request 처리
+        filterChain.doFilter(requestWrapper, responseWrapper)
+
+        // 로깅
+        logRequestResponse(requestWrapper, responseWrapper, System.currentTimeMillis() - startTime)
+
+        // response 전달
+        responseWrapper.copyBodyToResponse()
+    }
+
+    private fun logRequestResponse(
+        request: ContentCachingRequestWrapper,
+        response: ContentCachingResponseWrapper,
+        elapsedTime: Long,
+    ) {
+        val method = request.method
+        val uri = request.requestURI
+        val queryString = request.queryString?.let { "?$it" } ?: ""
+        val status = response.status
+
+        val requestBody = getRequestBody(request)
+        val responseBody = getResponseBody(response)
+
+        filterLogger.info("($elapsedTime ms) $method $uri$queryString | $status | $requestBody | $responseBody")
+    }
+
+    private fun getRequestBody(request: ContentCachingRequestWrapper): String {
+        val contentLength = request.contentLength
+        return when {
+            contentLength <= 0 -> "Empty body"
+            contentLength > loggingProperties.maxContentLength ->
+                "Too Large Body($contentLength bytes), summary: ${
+                    getBodySummary(
+                        request.contentAsByteArray,
+                        request.contentType,
+                    )
+                }"
+            else -> getCompactBody(request.contentAsByteArray)
+        }
+    }
+
+    private fun getResponseBody(response: ContentCachingResponseWrapper): String {
+        val contentLength = response.contentSize
+        return when {
+            contentLength <= 0 -> "Empty body"
+            contentLength > loggingProperties.maxContentLength ->
+                "Too Large Body($contentLength bytes), summary: ${
+                    getBodySummary(
+                        response.contentAsByteArray,
+                        response.contentType,
+                    )
+                }"
+            else -> getCompactBody(response.contentAsByteArray)
+        }
+    }
+
+    private fun getBodySummary(
+        content: ByteArray,
+        contentType: String?,
+    ): String {
+        val info = mutableListOf<String>()
+        info.add("Size: ${content.size} bytes")
+        info.add("Type: $contentType")
+        info.add("Preview: ${String(content.take(loggingProperties.previewLength).toByteArray())}...")
+        return info.joinToString(" | ")
+    }
+
+    private fun getCompactBody(content: ByteArray): String {
+        if (content.isEmpty()) return "-"
+
+        return try {
+            val bodyMap = objectMapper.readValue(content, Map::class.java)
+            val compactMap =
+                bodyMap.mapValues { (key, value) ->
+                    when {
+                        // 민감 정보 마스킹
+                        key.toString().lowercase(Locale.getDefault()).contains("token") -> "********"
+                        value is String && value.length > 100 -> "${value.substring(0, 97)}..."
+                        else -> value
+                    }
+                }
+            objectMapper.writeValueAsString(compactMap)
+        } catch (e: Exception) {
+            // JSON 파싱에 실패한 경우, 문자열의 일부만 반환
+            String(content).let { if (it.length > 100) "${it.substring(0, 97)}..." else it }
+        }
+    }
+}


### PR DESCRIPTION
## TicketingLoggingFilter 

- `logging.request-response.enabled` 이 true 일 때만, Component 로 만들어지도록 했습니다.
- 너무 큰 내용에 대해서는 메시지를 따로 만들어 로깅할 수 있도록 했습니다.

## FilterConfig

- TicketingLoggingFilter 를 Bean 으로 등록합니다.
- TicketingLoggingFilter 의 조건에 따라 Bean 으로 등록하도록 했습니다.

## LoggingProperties

- logging 관련 설정값을 이 class 로 주입받아 사용할 수 있도록 했습니다.
