### PR TITLE
STEP14_캐시 적용 및 시스템 설계

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-orgjson:0.12.6")
 
+    // for cache
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+
     // for swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
 
     // for redis
-    implementation("org.redisson:redisson-spring-boot-starter:3.33.0")
+    implementation("org.redisson:redisson-spring-boot-starter:3.34.1")
 
     // for jwt
     api("io.jsonwebtoken:jjwt-api:0.12.6")

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/dto/queue/WaitingInfoResult.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/dto/queue/WaitingInfoResult.kt
@@ -1,0 +1,18 @@
+package com.yuiyeong.ticketing.application.dto.queue
+
+import com.yuiyeong.ticketing.domain.model.queue.WaitingInfo
+
+data class WaitingInfoResult(
+    val position: Int,
+    val token: String,
+    val estimatedWaitingTime: Long,
+) {
+    companion object {
+        fun from(waitingInfo: WaitingInfo): WaitingInfoResult =
+            WaitingInfoResult(
+                position = waitingInfo.position,
+                token = waitingInfo.token,
+                estimatedWaitingTime = waitingInfo.estimatedWaitingTime,
+            )
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCase.kt
@@ -1,7 +1,5 @@
 package com.yuiyeong.ticketing.application.usecase.queue
 
-import com.yuiyeong.ticketing.application.dto.queue.QueueEntryResult
-
 interface ActivateWaitingEntriesUseCase {
-    fun execute(): List<QueueEntryResult>
+    fun execute(): Int
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/ActivateWaitingEntriesUseCaseImpl.kt
@@ -1,6 +1,5 @@
 package com.yuiyeong.ticketing.application.usecase.queue
 
-import com.yuiyeong.ticketing.application.dto.queue.QueueEntryResult
 import com.yuiyeong.ticketing.domain.service.queue.QueueService
 import org.springframework.stereotype.Component
 
@@ -8,5 +7,5 @@ import org.springframework.stereotype.Component
 class ActivateWaitingEntriesUseCaseImpl(
     private val queueService: QueueService,
 ) : ActivateWaitingEntriesUseCase {
-    override fun execute(): List<QueueEntryResult> = queueService.activateWaitingEntries().map { QueueEntryResult.from(it) }
+    override fun execute(): Int = queueService.activateWaitingEntries()
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/CheckActiveTokenUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/CheckActiveTokenUseCase.kt
@@ -1,0 +1,5 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+interface CheckActiveTokenUseCase {
+    fun execute(token: String)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/CheckActiveTokenUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/CheckActiveTokenUseCaseImpl.kt
@@ -1,0 +1,11 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.domain.service.queue.QueueService
+import org.springframework.stereotype.Component
+
+@Component
+class CheckActiveTokenUseCaseImpl(
+    private val queueService: QueueService,
+) : CheckActiveTokenUseCase {
+    override fun execute(token: String) = queueService.verifyTokenIsActive(token)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/EnterQueueUseCase.kt
@@ -1,7 +1,7 @@
 package com.yuiyeong.ticketing.application.usecase.queue
 
-import com.yuiyeong.ticketing.application.dto.queue.QueueEntryResult
+import com.yuiyeong.ticketing.application.dto.queue.WaitingInfoResult
 
 interface EnterQueueUseCase {
-    fun execute(userId: Long): QueueEntryResult
+    fun execute(userId: Long): WaitingInfoResult
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/GetWaitingInfoUseCase.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/GetWaitingInfoUseCase.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.queue.WaitingInfoResult
+
+interface GetWaitingInfoUseCase {
+    fun execute(token: String): WaitingInfoResult
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/GetWaitingInfoUseCaseImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/usecase/queue/GetWaitingInfoUseCaseImpl.kt
@@ -1,0 +1,28 @@
+package com.yuiyeong.ticketing.application.usecase.queue
+
+import com.yuiyeong.ticketing.application.dto.queue.WaitingInfoResult
+import com.yuiyeong.ticketing.domain.model.queue.WaitingInfo
+import com.yuiyeong.ticketing.domain.service.queue.QueueService
+import org.springframework.stereotype.Component
+
+@Component
+class GetWaitingInfoUseCaseImpl(
+    private val queueService: QueueService,
+) : GetWaitingInfoUseCase {
+    override fun execute(token: String): WaitingInfoResult {
+        queueService.verifyTokenIsInAnyQueue(token)
+
+        val waitingInfo =
+            queueService.getWaitingInfo(token) ?: WaitingInfo(
+                token,
+                POSITION_NOT_IN_WAITING_QUEUE,
+                WAITING_TIME_NOT_IN_WAITING_QUEUE,
+            )
+        return WaitingInfoResult.from(waitingInfo)
+    }
+
+    companion object {
+        private const val POSITION_NOT_IN_WAITING_QUEUE = 0
+        private const val WAITING_TIME_NOT_IN_WAITING_QUEUE = 0L
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/CacheConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/CacheConfig.kt
@@ -1,0 +1,15 @@
+package com.yuiyeong.ticketing.config
+
+import org.redisson.api.RedissonClient
+import org.redisson.spring.cache.RedissonSpringCacheManager
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@EnableCaching
+@Configuration
+class CacheConfig {
+    @Bean
+    fun cacheManager(redissonClient: RedissonClient): CacheManager = RedissonSpringCacheManager(redissonClient)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/CacheConfig.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/CacheConfig.kt
@@ -1,6 +1,8 @@
 package com.yuiyeong.ticketing.config
 
+import com.yuiyeong.ticketing.config.property.CachingProperties
 import org.redisson.api.RedissonClient
+import org.redisson.spring.cache.CacheConfig
 import org.redisson.spring.cache.RedissonSpringCacheManager
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
@@ -11,5 +13,22 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class CacheConfig {
     @Bean
-    fun cacheManager(redissonClient: RedissonClient): CacheManager = RedissonSpringCacheManager(redissonClient)
+    fun cacheManager(
+        redissonClient: RedissonClient,
+        properties: CachingProperties,
+    ): CacheManager {
+        val config: Map<String, CacheConfig> =
+            mapOf(
+                CacheNames.CONCERTS to CacheConfig(properties.ttlHour, properties.maxIdleTimeHalfHour),
+                CacheNames.AVAILABLE_EVENTS to CacheConfig(properties.ttlTenMin, properties.maxIdleTimeHalfTenMin),
+                CacheNames.CONCERT_EVENT to CacheConfig(properties.ttlTenMin, properties.maxIdleTimeHalfTenMin),
+            )
+        return RedissonSpringCacheManager(redissonClient, config)
+    }
+}
+
+object CacheNames {
+    const val CONCERTS = "concerts"
+    const val AVAILABLE_EVENTS = "availableEvents"
+    const val CONCERT_EVENT = "concertEvent"
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/property/CachingProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/property/CachingProperties.kt
@@ -1,0 +1,13 @@
+package com.yuiyeong.ticketing.config.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "config.caching")
+class CachingProperties {
+    var ttlHour: Long = 60 * 60 * 1000L // 1시간
+    var maxIdleTimeHalfHour: Long = 30 * 60 * 1000L // 30분
+    var ttlTenMin: Long = 10 * 60 * 1000L // 10분
+    var maxIdleTimeHalfTenMin: Long = 5 * 60 * 1000L // 5분
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/property/QueueProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/property/QueueProperties.kt
@@ -1,0 +1,14 @@
+package com.yuiyeong.ticketing.config.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "config.queue")
+class QueueProperties {
+    var tokenTtlInSeconds: Long = 60L * 60L // token 의 ttl 을 초 단위로; 60 분
+    var maxCountToMove: Int = 1000 // 활성화 시킬 토큰 수
+    var batchSizeToMoveToActive: Int = 500 // waiting token 에서 active token 으로 변경할 때 batch size
+    var activeRate: Long = 10 * 1000L // 활성화 주기; 10초
+    var estimatedWorkingTimeInMinutes: Long = 10L // 작업 시간을 분 단위로; 10분
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/property/SchedulerProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/property/SchedulerProperties.kt
@@ -7,6 +7,5 @@ import org.springframework.context.annotation.Configuration
 @ConfigurationProperties(prefix = "config.scheduler")
 class SchedulerProperties {
     var enabled: Boolean = true
-    var queueFixedRate: Long = 60000 // 1분
     var occupationFixedRate: Long = 60000 // 1분
 }

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/model/queue/WaitingInfo.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/model/queue/WaitingInfo.kt
@@ -1,0 +1,7 @@
+package com.yuiyeong.ticketing.domain.model.queue
+
+data class WaitingInfo(
+    val token: String,
+    val position: Int,
+    val estimatedWaitingTime: Long,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/repository/queue/QueueRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/repository/queue/QueueRepository.kt
@@ -1,0 +1,19 @@
+package com.yuiyeong.ticketing.domain.repository.queue
+
+interface QueueRepository {
+    fun addToWaitingQueue(token: String): Boolean
+
+    fun getWaitingQueuePosition(token: String): Int?
+
+    fun isInActiveQueue(token: String): Boolean
+
+    fun getActiveQueueSize(): Int
+
+    fun isInWaitingQueue(token: String): Boolean
+
+    fun getWaitingQueueSize(): Int
+
+    fun removeFromQueue(token: String): Boolean
+
+    fun moveToActiveQueue(countToMove: Int): Int
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/concert/ConcertService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/concert/ConcertService.kt
@@ -1,6 +1,7 @@
 package com.yuiyeong.ticketing.domain.service.concert
 
 import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.config.CacheNames
 import com.yuiyeong.ticketing.domain.exception.ConcertEventNotFoundException
 import com.yuiyeong.ticketing.domain.model.concert.Concert
 import com.yuiyeong.ticketing.domain.model.concert.ConcertEvent
@@ -20,18 +21,18 @@ class ConcertService(
     private val concertEventRepository: ConcertEventRepository,
     private val seatRepository: SeatRepository,
 ) {
-    @Cacheable(value = ["concerts"], key = "'all'")
+    @Cacheable(value = [CacheNames.CONCERTS], key = "'all'")
     @Transactional(readOnly = true)
     fun getConcerts(): List<Concert> = concertRepository.findAll()
 
-    @Cacheable(value = ["availableEvents"], key = "#concertId")
+    @Cacheable(value = [CacheNames.AVAILABLE_EVENTS], key = "#concertId")
     @Transactional(readOnly = true)
     fun getAvailableEvents(concertId: Long): List<ConcertEvent> {
         val now = ZonedDateTime.now().asUtc
         return concertEventRepository.findAllWithinPeriodBy(concertId, now)
     }
 
-    @Cacheable(value = ["concertEvents"], key = "#concertEventId")
+    @Cacheable(value = [CacheNames.CONCERT_EVENT], key = "#concertEventId")
     @Transactional(readOnly = true)
     fun getConcertEvent(concertEventId: Long): ConcertEvent {
         val concertEvent = concertEventRepository.findOneById(concertEventId) ?: throw ConcertEventNotFoundException()
@@ -46,7 +47,7 @@ class ConcertService(
         return seatRepository.findAllAvailableByConcertEventId(concertEvent.id)
     }
 
-    @CachePut(value = ["concertEvents"], key = "#concertEventId")
+    @CachePut(value = [CacheNames.CONCERT_EVENT], key = "#concertEventId")
     @Transactional
     fun refreshAvailableSeats(concertEventId: Long): ConcertEvent {
         val concertEvent =

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/concert/ConcertService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/concert/ConcertService.kt
@@ -8,6 +8,8 @@ import com.yuiyeong.ticketing.domain.model.concert.Seat
 import com.yuiyeong.ticketing.domain.repository.concert.ConcertEventRepository
 import com.yuiyeong.ticketing.domain.repository.concert.ConcertRepository
 import com.yuiyeong.ticketing.domain.repository.concert.SeatRepository
+import org.springframework.cache.annotation.CachePut
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.ZonedDateTime
@@ -18,15 +20,18 @@ class ConcertService(
     private val concertEventRepository: ConcertEventRepository,
     private val seatRepository: SeatRepository,
 ) {
+    @Cacheable(value = ["concerts"], key = "'all'")
     @Transactional(readOnly = true)
     fun getConcerts(): List<Concert> = concertRepository.findAll()
 
+    @Cacheable(value = ["availableEvents"], key = "#concertId")
     @Transactional(readOnly = true)
     fun getAvailableEvents(concertId: Long): List<ConcertEvent> {
         val now = ZonedDateTime.now().asUtc
         return concertEventRepository.findAllWithinPeriodBy(concertId, now)
     }
 
+    @Cacheable(value = ["concertEvents"], key = "#concertEventId")
     @Transactional(readOnly = true)
     fun getConcertEvent(concertEventId: Long): ConcertEvent {
         val concertEvent = concertEventRepository.findOneById(concertEventId) ?: throw ConcertEventNotFoundException()
@@ -41,6 +46,7 @@ class ConcertService(
         return seatRepository.findAllAvailableByConcertEventId(concertEvent.id)
     }
 
+    @CachePut(value = ["concertEvents"], key = "#concertEventId")
     @Transactional
     fun refreshAvailableSeats(concertEventId: Long): ConcertEvent {
         val concertEvent =

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/redis/repository/RedisQueueRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/redis/repository/RedisQueueRepository.kt
@@ -1,0 +1,110 @@
+package com.yuiyeong.ticketing.infrastructure.redis.repository
+
+import com.yuiyeong.ticketing.config.property.QueueProperties
+import com.yuiyeong.ticketing.domain.repository.queue.QueueRepository
+import org.redisson.api.ExpiredObjectListener
+import org.redisson.api.RScoredSortedSet
+import org.redisson.api.RSet
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+import java.time.Duration
+import kotlin.math.min
+
+@Repository
+class RedisQueueRepository(
+    queueProperties: QueueProperties,
+    private val redissonClient: RedissonClient,
+) : QueueRepository {
+    private val waitingQueue: RScoredSortedSet<String>
+        get() = redissonClient.getScoredSortedSet(KEY_WAITING_QUEUE)
+
+    private val activeQueue: RSet<String>
+        get() = redissonClient.getSet(KEY_ACTIVE_QUEUE)
+
+    private val ttl = Duration.ofSeconds(queueProperties.tokenTtlInSeconds)
+    private val batchSize = queueProperties.batchSizeToMoveToActive
+
+    private val logger = LoggerFactory.getLogger(RedisQueueRepository::class.java.simpleName)
+
+    override fun addToWaitingQueue(token: String): Boolean {
+        val score = System.currentTimeMillis().toDouble()
+        val isAdded = waitingQueue.add(score, token)
+        if (isAdded) {
+            setTokenTtl(token)
+        }
+        return isAdded
+    }
+
+    private fun setTokenTtl(token: String) {
+        val tokenTtlTracker = redissonClient.getBucket<String>(token)
+        tokenTtlTracker.addListener(
+            object : ExpiredObjectListener {
+                override fun onExpired(token: String) {
+                    removeFromQueue(token)
+                    logger.info("Token removed due to expiration;$token")
+                }
+            },
+        )
+        tokenTtlTracker.set(token, ttl)
+    }
+
+    override fun getWaitingQueuePosition(token: String): Int? {
+        val position = waitingQueue.rank(token) ?: return null
+        return position + 1
+    }
+
+    override fun isInActiveQueue(token: String): Boolean = activeQueue.contains(token)
+
+    override fun getActiveQueueSize(): Int = activeQueue.size
+
+    override fun isInWaitingQueue(token: String): Boolean = waitingQueue.contains(token)
+
+    override fun getWaitingQueueSize(): Int = waitingQueue.size()
+
+    override fun removeFromQueue(token: String): Boolean = waitingQueue.remove(token) || activeQueue.remove(token)
+
+    override fun moveToActiveQueue(countToMove: Int): Int {
+        if (countToMove == 0) return 0
+
+        val loopCount = (countToMove + batchSize - 1) / batchSize // 올림 처리해서 반복 횟수 계산
+        var remainingCount = countToMove
+        var totalMoved = 0
+
+        repeat(loopCount) {
+            val batchSize = min(batchSize, remainingCount)
+
+            try {
+                val count = moveWaitingQueueToActiveQueueAsBatch(batchSize)
+
+                totalMoved += count
+                remainingCount -= count
+            } catch (e: Exception) {
+                logger.warn("Error on [$loopCount] th moving tokens to active queue.", e)
+            }
+        }
+
+        return totalMoved
+    }
+
+    private fun moveWaitingQueueToActiveQueueAsBatch(batchSize: Int): Int {
+        val tokensWithScore = waitingQueue.pollFirstEntries(batchSize)
+        if (tokensWithScore.isEmpty()) return 0
+
+        val tokens = tokensWithScore.map { it.value }
+        val successToMoveCount = activeQueue.addAllCounted(tokens)
+
+        // active 가 되는데 실패한 token 들 원복
+        if (successToMoveCount < tokensWithScore.size) {
+            val failedTokens = tokensWithScore.takeLast(tokensWithScore.size - successToMoveCount)
+            waitingQueue.addAll(failedTokens.associate { it.value to it.score })
+        }
+
+        return successToMoveCount
+    }
+
+    companion object {
+        const val KEY_WAITING_QUEUE = "concert:waiting_queue"
+        const val KEY_ACTIVE_QUEUE = "concert:active_queue"
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/scheduler/QueueScheduler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/scheduler/QueueScheduler.kt
@@ -1,7 +1,6 @@
 package com.yuiyeong.ticketing.scheduler
 
 import com.yuiyeong.ticketing.application.usecase.queue.ActivateWaitingEntriesUseCase
-import com.yuiyeong.ticketing.application.usecase.queue.ExpireWaitingEntryUseCase
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
@@ -11,18 +10,14 @@ import org.springframework.stereotype.Component
 @ConditionalOnProperty(name = ["config.scheduler.enabled"], havingValue = "true", matchIfMissing = false)
 class QueueScheduler(
     private val activateWaitingEntriesUseCase: ActivateWaitingEntriesUseCase,
-    private val expireWaitingEntryUseCase: ExpireWaitingEntryUseCase,
 ) {
+    // TODO N 계산하기
     @Scheduled(fixedRateString = "#{@schedulerProperties.queueFixedRate}")
     fun processQueue() {
         try {
-            // token 만료
-            val expiredEntries = expireWaitingEntryUseCase.execute()
-            logger.info("Expired ${expiredEntries.size} entries.")
-
             // 대기 중인 항목 활성화
             val activatedEntries = activateWaitingEntriesUseCase.execute()
-            logger.info("Activated ${activatedEntries.size} entries.")
+            logger.info("Activated $activatedEntries entries.")
         } catch (e: Exception) {
             logger.error("Error from processingQueue: ${e.message}", e)
         }

--- a/src/main/kotlin/com/yuiyeong/ticketing/scheduler/QueueScheduler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/scheduler/QueueScheduler.kt
@@ -11,8 +11,7 @@ import org.springframework.stereotype.Component
 class QueueScheduler(
     private val activateWaitingEntriesUseCase: ActivateWaitingEntriesUseCase,
 ) {
-    // TODO N 계산하기
-    @Scheduled(fixedRateString = "#{@schedulerProperties.queueFixedRate}")
+    @Scheduled(fixedRateString = "#{@queueProperties.activeRate}")
     fun processQueue() {
         try {
             // 대기 중인 항목 활성화

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,11 @@ config:
     distributed-lock:
         acquire-timeout: 5000 # lock 획득까지 기다릴 시간; 5초
         lock-ttl: 10000 # distributed lock 의 만료 시간; 10초
+    queue:
+        token-ttl-in-seconds: 3600 # token 의 ttl 을 초 단위로; 3600 초
+        max-count-to-move: 1400 # 활성화할 토큰 수
+        batch-size-to-move-to-active: 500 # waiting token 에서 active token 으로 변경할 때 batch size
+        active-rate: 10000 # 활성화 주기; 10 초
     scheduler:
         enabled: true
-        queue-fixed-rate: 60000 # 1분
         occupation-fixed-rate: 60000 # 1분

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,8 @@ config:
     scheduler:
         enabled: true
         occupation-fixed-rate: 60000 # 1분
+    caching:
+        ttl-hour: 3600000  # 1시간
+        max-idle-time-half-hour: 1800000 # 30분
+        ttl-ten-min: 600000  # 10분
+        max-idle-time-half-ten-min: 300000  # 5분


### PR DESCRIPTION
## Caching

- 이 [보고서](https://github.com/yuiyeong/ticketing-service/blob/main/docs/report_about_caching.md) 를 바탕으로 필요한 부분에만 @Cacheable 을 추가하여 Caching 을 적용했습니다.
    - `ConcertService::getConcerts`
    - `ConcertService::getAvailableConcertEvents`
    - `ConcertService::getConcertEvent`

## 대기열

- 이 [보고서](https://github.com/yuiyeong/ticketing-service/blob/main/docs/report_about_queue_system.md) 의 내용을 바탕으로 구현했습니다.
    - QueueRepository 를 interface 로 추가
    - QueueRepository 를 Redis 로 구현한 RedisQueueRepository 추가
    - QueueService 에서 RedisQueueRepository 를 사용해서 비지니스 로직을 구현하도록 수정