### PR TITLE
Step 16

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
 
+    // for slack
+    implementation("com.slack.api:slack-api-client:1.40.3")
+
     /**************************** For Test ****************************/
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/event/PaymentEventHandler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/event/PaymentEventHandler.kt
@@ -1,0 +1,20 @@
+package com.yuiyeong.ticketing.application.event
+
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+import com.yuiyeong.ticketing.domain.notification.PaymentNotificationService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventHandler(
+    private val paymentNotificationService: PaymentNotificationService,
+) {
+    /**
+     * PaymentEvent 를 받아서 알림을 보내는 함수
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent) {
+        paymentNotificationService.notifyPaymentResult(event)
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/application/event/PaymentEventHandler.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/application/event/PaymentEventHandler.kt
@@ -2,6 +2,7 @@ package com.yuiyeong.ticketing.application.event
 
 import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
 import com.yuiyeong.ticketing.domain.notification.PaymentNotificationService
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -13,6 +14,7 @@ class PaymentEventHandler(
     /**
      * PaymentEvent 를 받아서 알림을 보내는 함수
      */
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handle(event: PaymentEvent) {
         paymentNotificationService.notifyPaymentResult(event)

--- a/src/main/kotlin/com/yuiyeong/ticketing/config/property/SlackProperties.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/config/property/SlackProperties.kt
@@ -1,0 +1,10 @@
+package com.yuiyeong.ticketing.config.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "slack")
+class SlackProperties {
+    var webhookUrl = ""
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/event/payment/PaymentEvent.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/event/payment/PaymentEvent.kt
@@ -1,0 +1,10 @@
+package com.yuiyeong.ticketing.domain.event.payment
+
+import com.yuiyeong.ticketing.domain.model.wallet.Transaction
+
+data class PaymentEvent(
+    val userId: Long,
+    val reservationId: Long,
+    val transaction: Transaction?,
+    val failureReason: String?,
+)

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/event/payment/PaymentEventPublisher.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/event/payment/PaymentEventPublisher.kt
@@ -1,0 +1,8 @@
+package com.yuiyeong.ticketing.domain.event.payment
+
+/**
+ * 결제 관련 이벤트를 발행하는 Publisher
+ */
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/notification/PaymentNotificationService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/notification/PaymentNotificationService.kt
@@ -1,0 +1,13 @@
+package com.yuiyeong.ticketing.domain.notification
+
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+
+/**
+ * 결제 관련 정보에 대한 알림을 보내는 Service
+ */
+interface PaymentNotificationService {
+    /**
+     * 결제 결과에 대한 알림을 보내는 함수
+     */
+    fun notifyPaymentResult(event: PaymentEvent)
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/domain/service/payment/PaymentService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/domain/service/payment/PaymentService.kt
@@ -1,5 +1,7 @@
 package com.yuiyeong.ticketing.domain.service.payment
 
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEventPublisher
 import com.yuiyeong.ticketing.domain.exception.ReservationNotFoundException
 import com.yuiyeong.ticketing.domain.exception.TransactionNotFoundException
 import com.yuiyeong.ticketing.domain.model.payment.Payment
@@ -14,6 +16,7 @@ class PaymentService(
     private val reservationRepository: ReservationRepository,
     private val transactionRepository: TransactionRepository,
     private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
 ) {
     @Transactional
     fun create(
@@ -29,6 +32,7 @@ class PaymentService(
             }
 
         val payment = Payment.create(userId, reservation, transaction, failureReason)
+        paymentEventPublisher.publish(PaymentEvent(userId, reservationId, transaction, failureReason))
         return paymentRepository.save(payment)
     }
 

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/slack/SlackPayloadCreator.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/slack/SlackPayloadCreator.kt
@@ -1,0 +1,27 @@
+package com.yuiyeong.ticketing.infrastructure.slack
+
+import com.slack.api.webhook.Payload
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+import org.springframework.stereotype.Component
+
+@Component
+class SlackPayloadCreator {
+    fun createPayloadFrom(paymentEvent: PaymentEvent): Payload =
+        Payload
+            .builder()
+            .text(
+                buildString {
+                    appendLine("<새로운 결제 완료되었습니다>")
+                    appendLine("사용자 ID: ${paymentEvent.userId}")
+                    appendLine("예약 ID: ${paymentEvent.reservationId}")
+                    if (paymentEvent.failureReason != null) {
+                        appendLine("결제 상태: 실패")
+                        appendLine("실패 사유: ${paymentEvent.failureReason}")
+                    } else {
+                        appendLine("결제 상태: 성공")
+                        appendLine("결제 금액: ${paymentEvent.transaction!!.amount}")
+                    }
+                    appendLine("-----------------")
+                },
+            ).build()
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/slack/SlackPaymentNotificationService.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/slack/SlackPaymentNotificationService.kt
@@ -1,0 +1,27 @@
+package com.yuiyeong.ticketing.infrastructure.slack
+
+import com.slack.api.Slack
+import com.yuiyeong.ticketing.config.property.SlackProperties
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+import com.yuiyeong.ticketing.domain.notification.PaymentNotificationService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class SlackPaymentNotificationService(
+    private val slackProperties: SlackProperties,
+    private val slackPayloadCreator: SlackPayloadCreator,
+) : PaymentNotificationService {
+    private val logger = LoggerFactory.getLogger(SlackPaymentNotificationService::class.java.simpleName)
+
+    private val slack = Slack.getInstance()
+
+    override fun notifyPaymentResult(event: PaymentEvent) {
+        val payload = slackPayloadCreator.createPayloadFrom(event)
+        try {
+            slack.send(slackProperties.webhookUrl, payload)
+        } catch (ex: Exception) {
+            logger.warn("Exception occurred while trying to send notification", ex)
+        }
+    }
+}

--- a/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/spring/SpringPaymentEventPublisher.kt
+++ b/src/main/kotlin/com/yuiyeong/ticketing/infrastructure/spring/SpringPaymentEventPublisher.kt
@@ -1,0 +1,15 @@
+package com.yuiyeong.ticketing.infrastructure.spring
+
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEvent
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class SpringPaymentEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
         time-zone: UTC
 
 
+slack:
+    webhook-url: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+
 logging:
     request-response:
         enabled: true

--- a/src/test/kotlin/com/yuiyeong/ticketing/unit/domain/service/payment/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/yuiyeong/ticketing/unit/domain/service/payment/PaymentServiceTest.kt
@@ -1,6 +1,7 @@
 package com.yuiyeong.ticketing.unit.domain.service.payment
 
 import com.yuiyeong.ticketing.common.asUtc
+import com.yuiyeong.ticketing.domain.event.payment.PaymentEventPublisher
 import com.yuiyeong.ticketing.domain.model.payment.Payment
 import com.yuiyeong.ticketing.domain.model.payment.PaymentStatus
 import com.yuiyeong.ticketing.domain.model.reservation.Reservation
@@ -35,11 +36,14 @@ class PaymentServiceTest {
     @Mock
     private lateinit var paymentRepository: PaymentRepository
 
+    @Mock
+    private lateinit var paymentEventPublisher: PaymentEventPublisher
+
     private lateinit var paymentService: PaymentService
 
     @BeforeEach
     fun beforeEach() {
-        paymentService = PaymentService(reservationRepository, transactionRepository, paymentRepository)
+        paymentService = PaymentService(reservationRepository, transactionRepository, paymentRepository, paymentEventPublisher)
     }
 
     @Test


### PR DESCRIPTION
## 보고서
- 서비스의 규모가 확장된다면 서비스들을 어떻게 분리하고 그 분리에 따른 트랜잭션 처리의 한계와 해결방안에 대한 서비스설계 문서는 아래 링크를 확인해주세요.
[콘서트 예약 시스템의 확장성 향상을 위한 서비스 분리 전략과 분산 트랜잭션 관리: MSA 전환 설계](https://github.com/yuiyeong/ticketing-service/blob/main/docs/report_about_msa.md)


---

## 결제 정보를 Slack 으로 보내는 비지니스 로직

- 결제 후 결제 정보를 생성하면, `PaymentEventPublisher` 로 `PaymentEvent` 를 발행합니다.
- `PaymentEventHandler` 에서 그 이벤트를 받아서, `PaymentNotificationService` 를 통해 결제 결과에 대한 알림을 보냅니다.
- `PaymentEventPublisher` 의 구현체인 `SpringPaymentEventPublisher` 에서 Spring 의 `ApplicationEventPublisher` 를 통해 이벤트를 발행합니다.
- `PaymentNotificationService` 의 구현체인 `SlackPaymentNotificationService` 에서 `PaymentEvent` 를 바탕으로 메시지를 만들어서 알림을 보냅니다.
- 현재는 `EventPublisher` 나 `NotificationService` 가 Payment 도메인에 대해서만 사용되고 있지만, 향후 범용적으로 사용할 수 있도록 추상화할 예정입니다.